### PR TITLE
Replace unsupported Bink videos with WebM.

### DIFF
--- a/compiled/avi/CyanWorlds.webm
+++ b/compiled/avi/CyanWorlds.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48f5d4670ab76956f557c6266cbb115fa02ec4bb54506aba9c90aa672bfa6c0
+size 881774

--- a/compiled/avi/Intro1.bik
+++ b/compiled/avi/Intro1.bik
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c42eae926818599fcb44bcf030f1ca462def47baf6c65a37e31893eddcc6c2d2
-size 4441368

--- a/compiled/avi/URULiveIntro.bik
+++ b/compiled/avi/URULiveIntro.bik
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c62f43e4d09fe7d2d863f9395d50aae0a066e16481fda17718d58f21bc0f94f8
-size 42103016

--- a/compiled/avi/URULiveIntro.webm
+++ b/compiled/avi/URULiveIntro.webm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:76df9d0812c61d30a4d7b626d21c9a907bc20b9b142a1236328cced083353f26
+size 3404265


### PR DESCRIPTION
These are the hastily converted videos we used on the Gehn Shard.