### PR TITLE
[Teledahn] Fix spurious workroom noise.

### DIFF
--- a/compiled/dat/Teledahn_District_tldnWorkroom.prp
+++ b/compiled/dat/Teledahn_District_tldnWorkroom.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f34e6ff71617df5c3224c0b233324147d5b84dd3630dfff25efbbb5474ec949b
-size 1635831
+oid sha256:d088f7202400be379ac98196ad8d088faa5aed67894e472a9013277c70e2b861
+size 1500726


### PR DESCRIPTION
Corrected the plSoundMsg in the workroom power stop responder to send the `kStop` command instead of `kPlay`, causing the screw turn noise to stop playing when the power is off. See original report on the [forum](https://forum.guildofwriters.org/viewtopic.php?p=75033#p75033).