### PR TITLE
Add Vothol Gallery to MOULa

### DIFF
--- a/compiled/dat/ChisoPreniv_District_Chiso.prp
+++ b/compiled/dat/ChisoPreniv_District_Chiso.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3bbf6a1d9ee08ccb577257b5120ccaf023759cf214e2316afe0acd37dad71ea2
-size 8997859
+oid sha256:034ab163e12b5335f4cb49f4fc61571c9978c1fb9760dd688a193fe34892599a
+size 8997864

--- a/compiled/dat/ChisoPreniv_District_FanContent.prp
+++ b/compiled/dat/ChisoPreniv_District_FanContent.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8adeeabda484c2e448061b17709f87a39931984ca0466fbb7f58428d87d0fe5
+oid sha256:28b9079600bb996b994e824aaac8732976fc8699d9134c4194ff5f749cfa32ca
 size 74903

--- a/compiled/dat/ChisoPreniv_District_Textures.prp
+++ b/compiled/dat/ChisoPreniv_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2067d3c59fd00a7e41315e6b5690c27d5b24d386fe32694c7069cb64664efdff
+oid sha256:68d399e2a7862477743fc00fcef8cc37f5a58285def2f923a8df75b03efffa1e
 size 80909798

--- a/compiled/dat/Vothol_District_BuiltIn.prp
+++ b/compiled/dat/Vothol_District_BuiltIn.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7d089213b73f6d1359b3f4d84c8eafb5dda2dbc74cb92d9d3cec876db277816
+size 320

--- a/compiled/dat/Vothol_District_ChisoBook.prp
+++ b/compiled/dat/Vothol_District_ChisoBook.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cac61f7fbdfe55fbdf5ee5c472cf8b5c1e602e44a9cd41efcc12c81e8128d0eb
+size 41102

--- a/compiled/dat/Vothol_District_Textures.prp
+++ b/compiled/dat/Vothol_District_Textures.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44f7ba0c99caec3e182ed79d95a24569ba286ad2d9c2053df6f18ed12f3858f1
+size 9678159

--- a/compiled/dat/Vothol_District_visitorlink.prp
+++ b/compiled/dat/Vothol_District_visitorlink.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aaa2604949c1dddf8f0ecf0b917cc60799093ff02428c41cfda46c99fb7e513b
+size 5369647

--- a/compiled/sfx/votholdomemusic.ogg
+++ b/compiled/sfx/votholdomemusic.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30296f377fb8939e030219b04f0ca317f4de6569d744ee849fe7bb59cc2629e7
+size 3737279


### PR DESCRIPTION
Adds PRPs and one SFX file for Vothol Gallery. It also changes Chiso slightly by rearranging the (future) Fehnir's House book and the Vothol book to avoid an empty pedestal in between.