### PR TITLE
Fix Relto dark hut problem in Windows 10 v2004+

### DIFF
--- a/compiled/dat/Personal_District_psnlMYSTII.prp
+++ b/compiled/dat/Personal_District_psnlMYSTII.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0a1ed89b8ce8e403e994ead165328d08c1bfbb61afc50830209f25a2996c244
-size 8590225
+oid sha256:92bb4c3a4595e79d60f7c9179aab8d92f3da7b7187f595bc8b90d145de72464b
+size 8588457


### PR DESCRIPTION
![darkhut](https://user-images.githubusercontent.com/714455/113335623-33480c00-92f3-11eb-8270-17a5948387c2.png)

After discussion in the DirectX discord, it was revealed that old hardware TnL spot lights would revert to affecting everything if the difference between the inner and outer cones was zero. As of Windows 10 v2004, the light cones supposedly function as expected. Previously, the cones differed by approximately 0.05 radians, which must have been sufficient to trigger the nearly 20 year standing bug. This changeset sets the inner cone to zero degrees, allowing the spot light to affect the entirety of the Relto hut. The outer cone value is unchanged.

If you look at the values in the PRPs, remember that Plasma spot light cones are stored as half radians. The dark light's cone is now approximately 91.5 degrees.
