### PR TITLE
Fix Neighborhood clock globe animation.

### DIFF
--- a/compiled/dat/Neighborhood_District_nb01.prp
+++ b/compiled/dat/Neighborhood_District_nb01.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:093331feebb7d96e594a8c85e235eff775a6284897ba480e7869bef8a06a8cb9
-size 7132387
+oid sha256:78eebf0e47ba557c8c3ae3638970b6c448e3fcee6ea7b8f649ab85849a296bcf
+size 7131465


### PR DESCRIPTION
[nbClockGlobe_(Entire Animation)_anim_0] Added a third keyframe to the clock rotation animation to cause the clock to actually rotate. Also converted to uncompressed quat keyframes due to lossy compression breaking the animation.