### PR TITLE
Fix render issues with user-created GZ Markers

### DIFF
--- a/compiled/dat/GlobalMarkers_District_Markers.prp
+++ b/compiled/dat/GlobalMarkers_District_Markers.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:866778fa9352d8879de9d653fd997dd7dfa7d28d8e3af8c555295b24f79aefa8
-size 34343
+oid sha256:e0b9b1410898f27138ff0dc572d74248262a1e202ae1a2a1b7709a5454d6478e
+size 34341


### PR DESCRIPTION
This is accomplished by changing the RenderLevel on the DSpans from `0x40000000` (BlendRendMajorLevel) to `0x80000001` (LateRendMajorLevel + 1).

Partly addresses GitHub issue #18.

![Screenshot from 2021-04-20 23-15-48](https://user-images.githubusercontent.com/241708/115509806-bcd46500-a233-11eb-8289-c98e5631d168.png)
