### PR TITLE
Nexus Age Sources

### DIFF
--- a/compiled/dat/Nexus_District_NexusAgeDialog.prp
+++ b/compiled/dat/Nexus_District_NexusAgeDialog.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fcf0a089c06c07ee5385a6af69420bd2fb2330890714acff3a86f6e11ec6089
-size 184493
+oid sha256:75b21e8f6060371d4b3e0d421d3b679dde4afc959c91e7af693d485261ca6e23
+size 184523

--- a/compiled/dat/Nexus_District_NexusAgeDialog.prp
+++ b/compiled/dat/Nexus_District_NexusAgeDialog.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:75b21e8f6060371d4b3e0d421d3b679dde4afc959c91e7af693d485261ca6e23
-size 184523
+oid sha256:ddb41ea414883eaf2a4577692bf642b34a6b8cf67dce325afc855fa7c29889b5
+size 184493

--- a/compiled/dat/Nexus_District_Textures.prp
+++ b/compiled/dat/Nexus_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eeec0d19a28c035d1bbf62e79b577757bccd7352c63aea0c4a9c7550c287a1fe
-size 10617169
+oid sha256:678e1df1e8431faa5118eac4857ea2bf81b71c7bafefb8a1af825317c7e27829
+size 10999319

--- a/compiled/dat/Nexus_District_Textures.prp
+++ b/compiled/dat/Nexus_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3a3dbd695dbcc9369e38dc1a77f1b0be9f70575f295be2d844ceb40578539d1d
-size 4643909
+oid sha256:eeec0d19a28c035d1bbf62e79b577757bccd7352c63aea0c4a9c7550c287a1fe
+size 10617169

--- a/compiled/dat/Nexus_District_nxusBookMachine.prp
+++ b/compiled/dat/Nexus_District_nxusBookMachine.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3da39c1f2a0c7a3dfc929b4b8ad80f4e5845d5ebab20c2099453fbe8352f5f78
-size 844196
+oid sha256:c7413e726ac9043080b34d89aee02052c8941874a2b95f7fbe0215c4d8285eff
+size 875418

--- a/compiled/dat/Nexus_District_nxusBookMachine.prp
+++ b/compiled/dat/Nexus_District_nxusBookMachine.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4a9b902f7a6a9e60504cf7cbee1aa045a5dcbf6054ff34d03366a9c9790a846d
-size 832348
+oid sha256:3da39c1f2a0c7a3dfc929b4b8ad80f4e5845d5ebab20c2099453fbe8352f5f78
+size 844196

--- a/sources/Nexus/DeleteBtn.tga
+++ b/sources/Nexus/DeleteBtn.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c485565125260f6c1e7363c3fe93083312cc75fac18217c87f0721d5e31ed60
+size 24620

--- a/sources/Nexus/GD01Gold.tga
+++ b/sources/Nexus/GD01Gold.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a367e9895fe359287a85f35960cef6f628890f832735685f0438fa57c02b9f8c
+size 196652

--- a/sources/Nexus/Grid.jpg
+++ b/sources/Nexus/Grid.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:643f911256484b253de8f29a5578bc2c5c9782535c94217f7903de92cf65d6d4
+size 6906

--- a/sources/Nexus/NB01linkpanelISLM.tga
+++ b/sources/Nexus/NB01linkpanelISLM.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c399e59cd49bce7f8ff91900f555e05356ef286b8491a2e429e555bb72832d3b
+size 49196

--- a/sources/Nexus/chbcBrickrow04cm.tga
+++ b/sources/Nexus/chbcBrickrow04cm.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ab5d5ad9b4221e057d5d5f6964e226defd49cd9be6a5fc163f998d75243cdee3
+size 12332

--- a/sources/Nexus/chbcBrickwalkwayconcretecm.tga
+++ b/sources/Nexus/chbcBrickwalkwayconcretecm.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6c968aa06fd0bd444dbc5b96893c7a94bea7c6788d9676c92f14bf4dba684d2
+size 98348

--- a/sources/Nexus/gd01LinkPanelNB01.tga
+++ b/sources/Nexus/gd01LinkPanelNB01.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c90699d7650fa1107c40784404e8ca3379d111483f7ba1e805e7cb9cf74be81c
+size 49196

--- a/sources/Nexus/gridBW.tga
+++ b/sources/Nexus/gridBW.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d0e3d68f5d8050a6e97553188c6f061b806c35f1182d5c1d1f30d216f89a5ba
+size 49196

--- a/sources/Nexus/grsnAluminumTrim.tga
+++ b/sources/Nexus/grsnAluminumTrim.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e694ceae7f1a5b02b86e8b6f064c638da4b7766a0658eaf555570e9695edda9
+size 65580

--- a/sources/Nexus/grsnCopperStrip.tga
+++ b/sources/Nexus/grsnCopperStrip.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21b316807688da0dff8bf00791573c32d6ec257891b777f4d84caf2b141bc45d
+size 262188

--- a/sources/Nexus/grsnDamagedAluminum.tga
+++ b/sources/Nexus/grsnDamagedAluminum.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92bd47d46d373e0a01e9c50d370a7004b1f1878e839a69a22584480ebe9a8b43
+size 262188

--- a/sources/Nexus/grsnDamagedAluminum02.tga
+++ b/sources/Nexus/grsnDamagedAluminum02.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e14e8c511be9f6a58a9bcd1a926eea3ec1cabcc60af6e1fa8ac0b1b5b97f6cd9
+size 196652

--- a/sources/Nexus/grsnGearRoomMetal.tga
+++ b/sources/Nexus/grsnGearRoomMetal.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb8f0c81260552118588382d1c2f339e6173570e63a0c8a22caa09cae174c296
+size 1048620

--- a/sources/Nexus/grsnHubcap2.tga
+++ b/sources/Nexus/grsnHubcap2.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ae0c3b1b6a07f6c700cf6718dadd40b27dac929938623336fdce2ef0c4af1f8
+size 262188

--- a/sources/Nexus/grsnMetalDome.tga
+++ b/sources/Nexus/grsnMetalDome.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:effa4a8bbdedb950a3cd75488c9b58f8120a8f7b2949e2c3a9c828853a8b352e
+size 1048620

--- a/sources/Nexus/grsnMudRmDoor.tga
+++ b/sources/Nexus/grsnMudRmDoor.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f5a9f0533125f10656ff6ebb7301c00063c2b365413831d3f06da0966ebd4f3
+size 2097196

--- a/sources/Nexus/grsnMudRmFloorLampE.tga
+++ b/sources/Nexus/grsnMudRmFloorLampE.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cad210714e559c2042d5d4de4b4a59535addf825029851bf05cf8d3345cdd40
+size 12332

--- a/sources/Nexus/grsnMudRmModCyl.tga
+++ b/sources/Nexus/grsnMudRmModCyl.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8954697539c1061f496e89d90cda7742e447189fe228223469689f675b59bfad
+size 2097196

--- a/sources/Nexus/grsnMudRmModuleCollar.tga
+++ b/sources/Nexus/grsnMudRmModuleCollar.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8accca6d2f964941715a6f7e3a06beda4889d99484be6518eb9c9aee886f35d2
+size 3466919

--- a/sources/Nexus/grsnMudRoomENV_BK.tga
+++ b/sources/Nexus/grsnMudRoomENV_BK.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:942dbff608c3e44af4dc6beee7c210612810a1d858738d4748ae2326cd39f84c
+size 49196

--- a/sources/Nexus/grsnMudRoomENV_DN.tga
+++ b/sources/Nexus/grsnMudRoomENV_DN.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1b451500c47498874d6355735cbdef465eededd0e411a8dc61178e67c9c07f38
+size 49196

--- a/sources/Nexus/grsnMudRoomENV_FR.tga
+++ b/sources/Nexus/grsnMudRoomENV_FR.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01b4c61c1b62241cb8407761530e3c57ac52ab269823eae5a2d33373fa7dd424
+size 49196

--- a/sources/Nexus/grsnMudRoomENV_LF.tga
+++ b/sources/Nexus/grsnMudRoomENV_LF.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63f3977cb8e2eb4a14d2a3a9ad2e40d7487358f5c2bf4fde175f939b56143f26
+size 49196

--- a/sources/Nexus/grsnMudRoomENV_RT.tga
+++ b/sources/Nexus/grsnMudRoomENV_RT.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ec6c4e1b47c63c634ebccd1f18d9ba47d5d39e2dbb62aaba8dd48e911c7f15f
+size 49196

--- a/sources/Nexus/grsnMudRoomENV_UP.tga
+++ b/sources/Nexus/grsnMudRoomENV_UP.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:915ee29e871e433b658a7053ebdddca6238b7017dfebc779fdb2ae8cf49cbfd5
+size 49196

--- a/sources/Nexus/grsnMudRoomModuleMain.tga
+++ b/sources/Nexus/grsnMudRoomModuleMain.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53387f3a5537f871c8fe5c94a5f93212eb5ad15fb020f1296ea770b5b9ba30cc
+size 262188

--- a/sources/Nexus/grsnRedLightKnob.tga
+++ b/sources/Nexus/grsnRedLightKnob.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1c992a82df4ae39b9533c8c511ebb31863ff1ae20d1817e2ae331da238345aa1
+size 262188

--- a/sources/Nexus/grsnRefrigeratorTextures.tga
+++ b/sources/Nexus/grsnRefrigeratorTextures.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b214737fd98852cab1210e01423a572d792387326926d70817bdfe72bfaf16
+size 4194348

--- a/sources/Nexus/grsnRibbedModuleTrim.tga
+++ b/sources/Nexus/grsnRibbedModuleTrim.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b95c5c59e68b59feb9ab6b0ee20efd021d6ec3cc40d8f1d60cc82e947bb7107a
+size 262188

--- a/sources/Nexus/grsnRustPlain.tga
+++ b/sources/Nexus/grsnRustPlain.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5311d8f711c4f930c85b6a6c6ed9ce9eb3799c7cb38d0af25f34baa3ac746986
+size 786476

--- a/sources/Nexus/grsnSocketPanel.tga
+++ b/sources/Nexus/grsnSocketPanel.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1a2a832b561daf5b4d312ad37fa55b7c86f55c3211770abe532037d616cb500
+size 1572908

--- a/sources/Nexus/grsnSuitAHelmet.tga
+++ b/sources/Nexus/grsnSuitAHelmet.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:51975b02710a2fe17bf6e2f9c3a33f21ebc20cb74b616cfc1d7ca7e625d4493a
+size 3145772

--- a/sources/Nexus/grsnTrnCtrHallStone03.tga
+++ b/sources/Nexus/grsnTrnCtrHallStone03.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2f348e2f7931fb49cf222d4618012a0c4e0be42a6d9db0f73623ecdd5667e869
+size 3145772

--- a/sources/Nexus/grsnTrnCtrHallStoneFloor.tga
+++ b/sources/Nexus/grsnTrnCtrHallStoneFloor.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8e5f959bdd053f532a26a6b2d6e3b2515043b8b3499e9a4092750c76c98903d
+size 786476

--- a/sources/Nexus/grsnTrnCtrMaintainersMkr.tga
+++ b/sources/Nexus/grsnTrnCtrMaintainersMkr.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd212f8ee46836d1df1d458e6f7c28d14d674a63a7f603df379a99a75c434b79
+size 196652

--- a/sources/Nexus/grsnWallPanelCoil.tga
+++ b/sources/Nexus/grsnWallPanelCoil.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:777284c0a04a4e38902848746481f08eb4f10ba232b21adfbb8e34e8bc0e92b3
+size 393234

--- a/sources/Nexus/grsnWellGearEnv_BK.tga
+++ b/sources/Nexus/grsnWellGearEnv_BK.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78b62f7f24d08b2a5b7dd0b3449b0d36ebd9b556a7cd8a05332ba55b3debe227
+size 49691

--- a/sources/Nexus/grsnWellGearEnv_DN.tga
+++ b/sources/Nexus/grsnWellGearEnv_DN.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a741cc327b2d0fe6b0844be935e6107e1864f41a4902c18075f44d31df707412
+size 49691

--- a/sources/Nexus/grsnWellGearEnv_FR.tga
+++ b/sources/Nexus/grsnWellGearEnv_FR.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c37ecbe727617c16c3cac295f913a6a39e155a70681b3aaa75278245efd1d3bd
+size 49691

--- a/sources/Nexus/grsnWellGearEnv_LF.tga
+++ b/sources/Nexus/grsnWellGearEnv_LF.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d3228141eb6a2a8c6754eed67b6f19d31d16f5759f024da68bddd214c51668f7
+size 49691

--- a/sources/Nexus/grsnWellGearEnv_RT.tga
+++ b/sources/Nexus/grsnWellGearEnv_RT.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3da387c64e82083d9c10890b96c8bad9309be37c4394ff26d33b2f44b59279ed
+size 49691

--- a/sources/Nexus/grsnWellGearEnv_UP.tga
+++ b/sources/Nexus/grsnWellGearEnv_UP.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b5bda653a06d3e51aeaba723b4c477b4c92d42baa83c3947301c18430c987bd
+size 49691

--- a/sources/Nexus/islmDniBook_page.tga
+++ b/sources/Nexus/islmDniBook_page.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb772b8b6623813e4cb7541c583a1ac70724ae0741b40be33a53b4e2e28c997
+size 786476

--- a/sources/Nexus/islmDniBook_page1.tga
+++ b/sources/Nexus/islmDniBook_page1.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb772b8b6623813e4cb7541c583a1ac70724ae0741b40be33a53b4e2e28c997
+size 786476

--- a/sources/Nexus/islmDniBook_side.tga
+++ b/sources/Nexus/islmDniBook_side.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cb78ef14a29cdad54e293869d5c9d67462736418b34a14eb62a9d099fec76bd
+size 98348

--- a/sources/Nexus/islmFTWndwWallBACK.tga
+++ b/sources/Nexus/islmFTWndwWallBACK.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:857c85de6e5ad8a1dcef3bc65b047b0f6da8b9e5b982713446fc48bdb1f5190d
+size 3145772

--- a/sources/Nexus/islmFTtxtStrp02Busted.tga
+++ b/sources/Nexus/islmFTtxtStrp02Busted.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:84b1ab902748d993903374467950da6fbf89426906427388e39a26e58792e1de
+size 393260

--- a/sources/Nexus/islmLIBRfacade.tga
+++ b/sources/Nexus/islmLIBRfacade.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f45d210b757f2e09cad91512e7c412448d8168db44050c5d6cdae6fc170492f1
+size 3145772

--- a/sources/Nexus/islmLIBRtpTrim.tga
+++ b/sources/Nexus/islmLIBRtpTrim.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0fab703f56ef9bbbbbfe66f27a74d29fa5e36edc246957539c818f6378165ee2
+size 393260

--- a/sources/Nexus/islmLIBstepPathBluV.tga
+++ b/sources/Nexus/islmLIBstepPathBluV.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bbf3b1bd021419c403b3a9e56f32ab2d75ea593cbea9b6c48b398684145bb44
+size 4194322

--- a/sources/Nexus/kdshGlowMetalStrip.tga
+++ b/sources/Nexus/kdshGlowMetalStrip.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ca3c359e89ff178372d6780a7d815ffc24c6977f53a3f90a1155a48b8cd15cd
+size 1048620

--- a/sources/Nexus/kdshLensFlareLightSource.tga
+++ b/sources/Nexus/kdshLensFlareLightSource.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e7034e2cfe289388d197b29f3282fc30de52293fc68e05c7bc76af7d0edc77d
+size 262188

--- a/sources/Nexus/kdshMetalCable.tga
+++ b/sources/Nexus/kdshMetalCable.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c6976f3f3236d0e4b75320337c328ec694f44a42c00bb0b416c009c07041a20
+size 196652

--- a/sources/Nexus/linkbtn.tga
+++ b/sources/Nexus/linkbtn.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f9f80a2fdd769be4a0b084a711e3f1ab6782ec576ba9faf8f8f074801dd93a5
+size 24620

--- a/sources/Nexus/nb01FountianBoardert.tga
+++ b/sources/Nexus/nb01FountianBoardert.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c86b270eb3c02fbc55f0013339e135c0198f18f9f80ab4ee97cb034561b9a4c
+size 786476

--- a/sources/Nexus/nb01ImagerNoiseMask.tga
+++ b/sources/Nexus/nb01ImagerNoiseMask.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:226d5cd14bfa6925e3f8dd9f4488f6f3e661cf542483c06345cf9e64a6b3ee44
+size 1048620

--- a/sources/Nexus/nb01LinkPanelGrsn.tga
+++ b/sources/Nexus/nb01LinkPanelGrsn.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c15a7f47c932264745a852b81b3de3efee3399bb41e3b3d7eecd91479b02eef0
+size 49196

--- a/sources/Nexus/nb01Plaza01Motif.tga
+++ b/sources/Nexus/nb01Plaza01Motif.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1be97ccac7e4d5c94e23dc916abff577f0c7be4b19a13b12f016c9541c88447
+size 1048620

--- a/sources/Nexus/nb01ResDesign02.tga
+++ b/sources/Nexus/nb01ResDesign02.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c24b1d91a1efd83b58db67144f11e21739b489421dbef2a60360924a17a45484
+size 196652

--- a/sources/Nexus/nb01StoneSquareCobble.tga
+++ b/sources/Nexus/nb01StoneSquareCobble.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6210f4169f895ffd07a6ec10d02441982c7c0ad0cd81ff830080cc34551e2e52
+size 3145772

--- a/sources/Nexus/nxusBookButton_UpDown.ogg
+++ b/sources/Nexus/nxusBookButton_UpDown.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e44b0d102e907a06256ad0e703d07bff397174878de74f6108410d16e67f174
+size 33811

--- a/sources/Nexus/nxusBookMachine.max
+++ b/sources/Nexus/nxusBookMachine.max
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:543ebecafd7c1380533c256e367651fef245470928e94418ac92fc7c2654b3db
-size 5706752
+oid sha256:342f58a887d00f6af5660737bc4f964a75cc3c6b3e5d214a181a3c6ecff89909
+size 5907456

--- a/sources/Nexus/nxusBookMachine.max
+++ b/sources/Nexus/nxusBookMachine.max
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cf9f7bb64379d49c69e35f6b41cb6e65ddf0b9d29a040fb7b0fa9edd6d50bd77
-size 5689856
+oid sha256:543ebecafd7c1380533c256e367651fef245470928e94418ac92fc7c2654b3db
+size 5706752

--- a/sources/Nexus/nxusBookMachine.max
+++ b/sources/Nexus/nxusBookMachine.max
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf9f7bb64379d49c69e35f6b41cb6e65ddf0b9d29a040fb7b0fa9edd6d50bd77
+size 5689856

--- a/sources/Nexus/nxusBookPutBack.ogg
+++ b/sources/Nexus/nxusBookPutBack.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e21ff493037367837b41da325906916e3e3c7a71d83b1b4334a6305e6c7409e
+size 35742

--- a/sources/Nexus/nxusBookRetrieval.ogg
+++ b/sources/Nexus/nxusBookRetrieval.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5126bd09cd33d0a404f3118c08ea038bb0f0ac3aa75bb7a7473b5995e9144cd
+size 106135

--- a/sources/Nexus/nxusENV_BK.tga
+++ b/sources/Nexus/nxusENV_BK.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d74f14515a80337375403699cfd3f09cd3e321cbe49c55ef8b10956051105162
+size 49691

--- a/sources/Nexus/nxusENV_DN.tga
+++ b/sources/Nexus/nxusENV_DN.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9d769e435f59078acfd77bf555f525f122b9b7f3576b1e486b441f58d23869e
+size 49691

--- a/sources/Nexus/nxusENV_FR.tga
+++ b/sources/Nexus/nxusENV_FR.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:226694c62ccfad362d4ce455e89052973f63e07e9f22c0e19e1f5181ec8e0c44
+size 49691

--- a/sources/Nexus/nxusENV_LF.tga
+++ b/sources/Nexus/nxusENV_LF.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd8027d4774260a0637ba1b9c4282be14fcc71c6fe00f792032e766e1741a0ed
+size 49691

--- a/sources/Nexus/nxusENV_RT.tga
+++ b/sources/Nexus/nxusENV_RT.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:666376eb950ee51e56c8936a8f14e2d53dbfd3dcd2562a7a9341df75f204ed51
+size 49691

--- a/sources/Nexus/nxusENV_UP.tga
+++ b/sources/Nexus/nxusENV_UP.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2347e2d1f8444b7dd5aef8a1af0a4392395c42a33c2baff9363904ec4aa4212
+size 49691

--- a/sources/Nexus/nxusGearAmb_loop.ogg
+++ b/sources/Nexus/nxusGearAmb_loop.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:834c3c6fc3b5bc57b80304d3d027013b67fb0969f69998e5427088a4857a9fc1
+size 158278

--- a/sources/Nexus/nxusGearToothMetal.tga
+++ b/sources/Nexus/nxusGearToothMetal.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:efac0059202bbe2821c77a47a9b0f3a40c7618148b9974544585eef9180efae2
+size 196652

--- a/sources/Nexus/nxusGearToothMetalSkin.tga
+++ b/sources/Nexus/nxusGearToothMetalSkin.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e2fff291e3aa5821960fb976391972ffaf1c99a60e39ef0f402562cff839999
+size 786476

--- a/sources/Nexus/nxusKI-LogoGlow.tga
+++ b/sources/Nexus/nxusKI-LogoGlow.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0308b8684e5a1df10c1f2874be0c7cfe8173ab67b2aab5879fa46bd5c3f13400
+size 196652

--- a/sources/Nexus/nxusKI-LogoStone.tga
+++ b/sources/Nexus/nxusKI-LogoStone.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d657fa6de4a1211317da31552eabdcce257822ade44dcf1fd82474985f49b859
+size 262188

--- a/sources/Nexus/nxusKI-SlotDevice_AwayReturn.ogg
+++ b/sources/Nexus/nxusKI-SlotDevice_AwayReturn.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44ae493ccc4eea4a6bc0fd9dbc621c31bf15b028b3fca3d5e797a91fada5281f
+size 105695

--- a/sources/Nexus/nxusLinkPanel.tga
+++ b/sources/Nexus/nxusLinkPanel.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a26709c80846c56ce47a800e6448d099cc40915e7c8304ae541dff0e6f00dc76
+size 196652

--- a/sources/Nexus/nxusLinkPanelConcertHallFoyer.tga
+++ b/sources/Nexus/nxusLinkPanelConcertHallFoyer.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5379df331d024582f1125b7bf4b3048b2aac07a455dc72cd044f1ab5af36c02c
+size 196652

--- a/sources/Nexus/nxusLinkPanelDakotahAlley.tga
+++ b/sources/Nexus/nxusLinkPanelDakotahAlley.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cb9793d6996e6d236699eb31de2ba6c53642b5cb4127724b0c513e767aefae1
+size 196652

--- a/sources/Nexus/nxusLinkPanelFerryTerminal.tga
+++ b/sources/Nexus/nxusLinkPanelFerryTerminal.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:70e2a679446d10cf15d3110698b5a71ae292be7c2793acc4e57c8e0d753a4a56
+size 196652

--- a/sources/Nexus/nxusLinkPanelLibraryCourtyard.tga
+++ b/sources/Nexus/nxusLinkPanelLibraryCourtyard.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:222a5db4d3a107060ccf6f95d17581f65bbf486d92b2c71892db0870b9773f17
+size 196652

--- a/sources/Nexus/nxusLinkPanelPalaceAlcove.tga
+++ b/sources/Nexus/nxusLinkPanelPalaceAlcove.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:663435bc932563433a3f6d074f717255b95b659f858d2655b3d23d07b28ea311
+size 196652

--- a/sources/Nexus/nxusNewBook.tga
+++ b/sources/Nexus/nxusNewBook.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0a5ed051b1151f2222f7db2f38f9014f73e00c4461050b4989a03b1d9c70289
+size 65580

--- a/sources/Nexus/nxusSymbolEngraved.tga
+++ b/sources/Nexus/nxusSymbolEngraved.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29673611e1466df7877faec0e0a57bcdfa857c090b4a63a014755495c609c097
+size 245432

--- a/sources/Nexus/nxusSymbolGLOW.tga
+++ b/sources/Nexus/nxusSymbolGLOW.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c681e3abbd65efdd606dfdf795c15c12ed2bbd7e2fe2ced50c6a2dcf75ce7c54
+size 65580

--- a/sources/Nexus/nxusWhite16Square.tga
+++ b/sources/Nexus/nxusWhite16Square.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe811d05291fb913145eb1574e06444c813fb15b78bc5d9fd52e2a62c89d72b9
+size 812

--- a/sources/Nexus/psnlBookCover.tga
+++ b/sources/Nexus/psnlBookCover.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9dacfad0fe5b4761b83a58a4b47281ba4ce943a378a2ae1d70199d5ab10eb9a1
+size 24620

--- a/sources/Nexus/psnlBookCover01.tga
+++ b/sources/Nexus/psnlBookCover01.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6389a1197e2cf4fee1669313e0021a67be68747e4dd258b96ab78943c67599cf
+size 12332

--- a/sources/Nexus/psnlBookCovers.tga
+++ b/sources/Nexus/psnlBookCovers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77d10198fee05bb15d88b65cb9499905678e716ef680d8e5767d45fcdf194257
+size 3145772

--- a/sources/Nexus/psnlBookSide01.tga
+++ b/sources/Nexus/psnlBookSide01.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71c501d86141804420c6e58b7d9b26afbfbc884caa907d6973133d0722075283
+size 3116

--- a/sources/Nexus/shrmD1.tga
+++ b/sources/Nexus/shrmD1.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e08c6edce381f2dd1f8980df96fdb624fdffa1db8c44859053c95501b08e965
+size 1042

--- a/sources/Nexus/xBookLinkPanels.tga
+++ b/sources/Nexus/xBookLinkPanels.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e26e4d6cfc598e933b54af7cd75327eaae8136ee5b50b66334c737712a3c205
+size 3145772

--- a/sources/Nexus/xBookLinkPanels02.tga
+++ b/sources/Nexus/xBookLinkPanels02.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42e4ba226943b43f3430b67434ab7b5481f4b561e9f44f95d6e01903f9d6456a
+size 3145772

--- a/sources/Nexus/xBookNewPage.tga
+++ b/sources/Nexus/xBookNewPage.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06fb18b7e03c7b6e52cb032c57b1e62e1221e1700cec5bbe498e2f9ea1d103b5
+size 786476

--- a/sources/Nexus/xBookPage.tga
+++ b/sources/Nexus/xBookPage.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb772b8b6623813e4cb7541c583a1ac70724ae0741b40be33a53b4e2e28c997
+size 786476

--- a/sources/Nexus/xImagerNexus_Loop.ogg
+++ b/sources/Nexus/xImagerNexus_Loop.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b4271d416623d8124868c3ed0cab3fbb40889752d982ee9bef9af87c87ca120d
+size 48713

--- a/sources/Nexus/xKIImagerInterface2.tga
+++ b/sources/Nexus/xKIImagerInterface2.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea9844f934f587de7889712590b64b5661d49e5439ec40c2472d9a5ad50a3d78
+size 1048620

--- a/sources/Nexus/xKIImagerNoiseOpaq.tga
+++ b/sources/Nexus/xKIImagerNoiseOpaq.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad8ea60a69df0293bdd62e9da745e58d3f7f128c1466eb6c369716e5b2e87501
+size 1048620

--- a/sources/Nexus/xKIOpenClose.ogg
+++ b/sources/Nexus/xKIOpenClose.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cab17ca0fa15e51d7f4b0ff42c5669f73b6fc37f0fc4bbf997476b56ad6545b7
+size 42186

--- a/sources/Nexus/xKISlotGlow.ogg
+++ b/sources/Nexus/xKISlotGlow.ogg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c63cef23739f630293cc94145ec578829e888f213b8e834925378aa662f34aee
+size 26269

--- a/sources/Nexus/xLinkPanelAhnonayTemple.tga
+++ b/sources/Nexus/xLinkPanelAhnonayTemple.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a680ef4b664057be219965dde824f448081a9823aae2a07b3d7345a759a01422
+size 524332

--- a/sources/Nexus/xLinkPanelBevinDefault.tga
+++ b/sources/Nexus/xLinkPanelBevinDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:167e56415248a74fd50e0a7b8b7347805863490cf76e34b60bb245507f179a8e
+size 524332

--- a/sources/Nexus/xLinkPanelChisoPreniv.tga
+++ b/sources/Nexus/xLinkPanelChisoPreniv.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc25c15be48d2b09eb0e83d6b9741ca92ccd1f1b310ac9a6c72bb1abb3b8af3b
+size 524332

--- a/sources/Nexus/xLinkPanelCleftDesert.tga
+++ b/sources/Nexus/xLinkPanelCleftDesert.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ec1b1084e49229258910bb008363dbab6e28605902a2e211b02c50a0d3c372d
+size 524332

--- a/sources/Nexus/xLinkPanelDerenoDefault.tga
+++ b/sources/Nexus/xLinkPanelDerenoDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c66c81b474b0a33d565c22991dd82f1a4056d8db2448550513e46684810fed6
+size 524332

--- a/sources/Nexus/xLinkPanelDescentShaftFall.tga
+++ b/sources/Nexus/xLinkPanelDescentShaftFall.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:095ae0fc996e3acf918dfb30494159b5f8fd89cb4793dcc19f3f59abe905646d
+size 524332

--- a/sources/Nexus/xLinkPanelErcanaDefault.tga
+++ b/sources/Nexus/xLinkPanelErcanaDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b11596c49921434de1b93e63969db5fcc9e930160509eb0addcd37f0b3359d
+size 524332

--- a/sources/Nexus/xLinkPanelFehnirHouse.tga
+++ b/sources/Nexus/xLinkPanelFehnirHouse.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:255e1f0dd66dcac30055069dff003591a38ddd1cc2c08a614c95ba1920ea19ba
+size 839684

--- a/sources/Nexus/xLinkPanelGardenDefault.tga
+++ b/sources/Nexus/xLinkPanelGardenDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6473dec98102b2f76794537ca325500b403b341f8953284905e439c55f2d242b
+size 524332

--- a/sources/Nexus/xLinkPanelGarrisonDefault.tga
+++ b/sources/Nexus/xLinkPanelGarrisonDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba7695602fcc0c8a758a04f1409e8a73bd3248be8fdd56dff7a1b6629edff9ff
+size 524332

--- a/sources/Nexus/xLinkPanelGiraDefault.tga
+++ b/sources/Nexus/xLinkPanelGiraDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5645580e1a616cc54b0194cb811e9c028b83a23f9a92d965b08734fadf867d8b
+size 524332

--- a/sources/Nexus/xLinkPanelGoMePubNew.tga
+++ b/sources/Nexus/xLinkPanelGoMePubNew.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:06fc99653d917f64f5c531f19e89a6a56134d8a89a49dfc5819ac9212b935e8e
+size 198279

--- a/sources/Nexus/xLinkPanelGreatTreePubDefault.tga
+++ b/sources/Nexus/xLinkPanelGreatTreePubDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:507f7a2550d2fae28e08a3c0e4797a16a468f32624fa34ddf5cc485646654565
+size 524332

--- a/sources/Nexus/xLinkPanelGrtZero.tga
+++ b/sources/Nexus/xLinkPanelGrtZero.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cba671ea0e28a2f5152ba945e7763935f5d62209a24c22bb3e70ceed9fd1ee8b
+size 524332

--- a/sources/Nexus/xLinkPanelGrtZeroLinkRm.tga
+++ b/sources/Nexus/xLinkPanelGrtZeroLinkRm.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e4077e30f332d4909c2ec757e5f02519639ed90a511d86101b50decbf2b006b
+size 524332

--- a/sources/Nexus/xLinkPanelGuildPubCartographers.tga
+++ b/sources/Nexus/xLinkPanelGuildPubCartographers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d65b92f9289aba800633c05b1e432b48debf7990735965b4f2c03b522102883
+size 524332

--- a/sources/Nexus/xLinkPanelGuildPubGreeters.tga
+++ b/sources/Nexus/xLinkPanelGuildPubGreeters.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78f198659002586199546fa8c4d9d67d97c53f6a32d3480263d2921b3abf9983
+size 524332

--- a/sources/Nexus/xLinkPanelGuildPubMaintainers.tga
+++ b/sources/Nexus/xLinkPanelGuildPubMaintainers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d67e3e568389d275eca02a5e37857aff9ff320ddb634297fca45635cef8c10ec
+size 524332

--- a/sources/Nexus/xLinkPanelGuildPubMessengers.tga
+++ b/sources/Nexus/xLinkPanelGuildPubMessengers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2247dad7bf19a417b891d2e70ef941499e3075cab6a4a4c4c04bd90e073043ab
+size 524332

--- a/sources/Nexus/xLinkPanelGuildPubWriters.tga
+++ b/sources/Nexus/xLinkPanelGuildPubWriters.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6f3b5d64207232005bb601ac3f5c873aa4004993d9180661f3e6b821d0f079f
+size 524332

--- a/sources/Nexus/xLinkPanelJalakDefault.tga
+++ b/sources/Nexus/xLinkPanelJalakDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bc839ebfe269aea6fd8aedae7a2cd443c9c8fda6c622f9306c2e332db266b140
+size 524332

--- a/sources/Nexus/xLinkPanelKadishDefault.tga
+++ b/sources/Nexus/xLinkPanelKadishDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3600621e99654fe5762f15a083a85d149947a0ed2e4d01d49eabfcf6d8b90216
+size 524332

--- a/sources/Nexus/xLinkPanelKirel.tga
+++ b/sources/Nexus/xLinkPanelKirel.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12e78d42bc27da0948a6e9bcf3b51431e14d8862e0588855b0f6ad1a0aaa16bf
+size 524332

--- a/sources/Nexus/xLinkPanelKveerGreatHall.tga
+++ b/sources/Nexus/xLinkPanelKveerGreatHall.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a080e884c1b22d7cc44b02bd8f0ddf7a99ef0c408c11608505fe0f065faa3739
+size 524332

--- a/sources/Nexus/xLinkPanelNegilahnDefault.tga
+++ b/sources/Nexus/xLinkPanelNegilahnDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1560bf844ecae909f21a0fe27bf2c0065225087b73d5785f091d63e112ed58c3
+size 524332

--- a/sources/Nexus/xLinkPanelPayiferenDefault.tga
+++ b/sources/Nexus/xLinkPanelPayiferenDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7318d0d4dae5a961ba6cf31a306f59005fa8463bf0e4acf2e3007a5ed4e3a636
+size 524332

--- a/sources/Nexus/xLinkPanelTetsonotDefault.tga
+++ b/sources/Nexus/xLinkPanelTetsonotDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e2d19e7e25738aecfd4f014878afc2c0cd59e76c74bf05fbf0b9be46a9fb225
+size 524332

--- a/sources/Nexus/xLinkPanelTomahnaDesert.tga
+++ b/sources/Nexus/xLinkPanelTomahnaDesert.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:156081171f6f52beb09311c1d0c5ef2465c5c39ae2f65e17e5a553b96d8adb62
+size 524332

--- a/sources/Nexus/xLinkPanelVeeTsah.tga
+++ b/sources/Nexus/xLinkPanelVeeTsah.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:50e929ca366a9f952ba7d96e56f463f848a3c805704f72f7e25a1d8867f37f6a
+size 252217

--- a/sources/Nexus/xLinkPanelVothol.tga
+++ b/sources/Nexus/xLinkPanelVothol.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c8c01cfe8b97b6b258915b56a3cbc13568ad7fa5fe10f1302e3946207bcc87
+size 260385

--- a/sources/Nexus/xLinkpanelMinkataDefault.tga
+++ b/sources/Nexus/xLinkpanelMinkataDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01655e544fc022c7408942bfad31efb232653562d015e76db72844c89256e92d
+size 524332

--- a/sources/Nexus/xLinkpanelTeledahnDefault.tga
+++ b/sources/Nexus/xLinkpanelTeledahnDefault.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f3ca64f63404a76a013ab5d3597130da325499d1273359dacac8ed288e73d67
+size 524332

--- a/sources/Nexus/xYeeshaBookOpen.tga
+++ b/sources/Nexus/xYeeshaBookOpen.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:647128b20567c4b11b7e43438bc44afa4a2d03399a68812a8aed2a729ae9cfad
+size 4194348


### PR DESCRIPTION
Per discussion with @markdef, these can also be released under the terms of the CC-BY-SA-NC 4,0 because they were in a second batch of Intangible assets. Therefore the appropriate commits have been picked over from the Gehn Shard repository.