### PR TITLE
Fixes First Week Reward Clothing

### DIFF
--- a/compiled/dat/city_District_ferry.prp
+++ b/compiled/dat/city_District_ferry.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ffea779b1f101811f52814dd9595df8995490ecb1471954f9fe79e0fb20ec50
-size 3004421
+oid sha256:769f4b2c70301fec00648694dae0c88fbccf0b3f787f10e197b6c926953a089e
+size 3004423


### PR DESCRIPTION
Wrong shirt was assigned in python file mod for first week shirt. This fixes that issue.

[Python File Mod - cPythFirstWeekShirtTakable - 4] Changed to "FReward_Launch"
[Python File Mod - cPythFirstWeekShirtTakable - 5] Changed to "MReward_Launch"