### PR TITLE
Fix solid bendy bridge in Teledahn.

### DIFF
--- a/compiled/dat/Teledahn_District_tldnHarvest.prp
+++ b/compiled/dat/Teledahn_District_tldnHarvest.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b14d959de1472d611552d7a4f10edfe0f9e250c5e71b6e999ef6e91b4516f655
-size 8973157
+oid sha256:57adeea243fb92ef0963a57a045fe60619113fc00c20ce00560a652237bd028e
+size 8769697


### PR DESCRIPTION
[PXPhysical] Bendy Bridge
Changed the member group from kGroupDynamic to kGroupStatic. The previous setting is for kickables (which this bridge is not). PhysX does not allow for non-kinematic dynamic bodies to have triangle mesh bounds. Because of the improper member group, we were forcing PhysX to treat the triangle mesh bounds as a convex hull, making the whole bridge solid.

Or, as Simulation.0.log says:
`WARNING: 'BendyBridge' is a dynamic triangle mesh; this is not supported in PhysX 4... forcing to convex hull, sorry.`