### PR TITLE
Er'cana Fix Rollup

### DIFF
--- a/compiled/dat/Ercana_District_Canyon.prp
+++ b/compiled/dat/Ercana_District_Canyon.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c81ef52306edb27bb3cbdc7d1804828c67bb036258f62aa35b744a5a8b561ec3
-size 4831759
+oid sha256:6191e52ac3e30a96465db37e699bcb7df42eedbb7898c8ffb1182ca777886781
+size 4626769

--- a/compiled/dat/Ercana_District_Canyon.prp
+++ b/compiled/dat/Ercana_District_Canyon.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6191e52ac3e30a96465db37e699bcb7df42eedbb7898c8ffb1182ca777886781
-size 4626769
+oid sha256:9850b5097be7fc53b934dece960eaca885d3ad99ceec32c338740e35129375a0
+size 4626636

--- a/compiled/dat/Ercana_District_Canyon.prp
+++ b/compiled/dat/Ercana_District_Canyon.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9850b5097be7fc53b934dece960eaca885d3ad99ceec32c338740e35129375a0
+oid sha256:1a1b42290f9265c68271dc9f656bc8e8ad05580483faa2d611e96aa0b7054986
 size 4626636

--- a/compiled/dat/Ercana_District_PelletRm.prp
+++ b/compiled/dat/Ercana_District_PelletRm.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f50e7183d96ee1d8417eebf1d62d9e4f73bd8c8cdff1b5cdb098bc6ba7632138
+oid sha256:2aea576ffcbe26f11f869212573c0fd7f734200240c01f3a29c363eb8b9a4012
 size 800382


### PR DESCRIPTION
Requires H-uru/Plasma#954

Per @dgelessus
> * Have the harvester docked at the facility, with the little cart moved up/inside the facility
> * Board the harvester without moving the cart back down (easiest by Reltoing out and returning via the original link-in point)
> * Set the harvester to backwards direction
> * Push the call button for the little cart (on the harvester control panel)
> * Before the little cart arrives at the harvester, start the harvester so it moves away from the facility without the cart
> Now once the little cart arrives at the bottom, both the cart and the harvester lower their wooden bridges. Normally the cart should now be connected to the harvester, but it isn't, because you moved the harvester away first. Now you can simply walk off the wooden bridges on the harvester and you will fall through the world. The situation fixes itself once you send the harvester back to the facility and have it connect to the cart again.

This fixes:
- The bridges only lower if the harvester and car are stopped in the same location, preventing a trivial fall-from-world.
- The car no longer warps itself back to the beginning if you stop the harvester while the car is detached at the base of the factory.
- The car no longer warps itself to the bottom of the factory if you stop the harvester while the car is moving down from the silo to the base of the factory.