### PR TITLE
Re-export Fan02 clothing with PNG icons.

### DIFF
--- a/compiled/dat/GlobalClothing_District_FemaleFan02.prp
+++ b/compiled/dat/GlobalClothing_District_FemaleFan02.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:199d07cf504aac43f659beadd96207bdc8a06990ce3666d14210db4bb01109ea
-size 544317
+oid sha256:6cc8a85b3a8b898eb56ce5fb489a27377be4d89574d2f1821f449bf31196c235
+size 558554

--- a/compiled/dat/GlobalClothing_District_MaleFan02.prp
+++ b/compiled/dat/GlobalClothing_District_MaleFan02.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:023391971be16f778aa5b97d4f7c414cf0a1d88523b427ec7872ede4832b4fcb
-size 544431
+oid sha256:6c5f233d16a9854abade09460fb1be1f0a59fb258487322bf944062145983e7e
+size 558668


### PR DESCRIPTION
As of H-uru/Plasma#942, this is now supported. The GZ Pride shirt's icon is now very nice.

![Screenshot 2021-07-13 17 04 10](https://user-images.githubusercontent.com/714455/125525177-8d92352d-cf9e-4ca6-b58e-652d0effd5ff.png)
