### PR TITLE
Kadish Elevator fix

### DIFF
--- a/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
+++ b/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5bb954807f652d96279b370f60d8bc4cd6574c53d9e78c5caf3ee70f0aee0a19
+oid sha256:d2551ad57f528873c551729bcc3430945cb5b7ff97a64521a8bd00f2618e86fe
 size 2520152

--- a/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
+++ b/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d2551ad57f528873c551729bcc3430945cb5b7ff97a64521a8bd00f2618e86fe
+oid sha256:e8d7aa2cee5a7269e5656a5001f13c563eeaa804ebfff326d35b23cbb2ecada3
 size 2520152

--- a/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
+++ b/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4b088bbc28a28714c2a7076a99f052fd8560c069b532487f1d9aed130161190
-size 2520284
+oid sha256:5bb954807f652d96279b370f60d8bc4cd6574c53d9e78c5caf3ee70f0aee0a19
+size 2520152

--- a/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
+++ b/compiled/dat/Kadish_District_kdshGlowInTheDark.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e8d7aa2cee5a7269e5656a5001f13c563eeaa804ebfff326d35b23cbb2ecada3
-size 2520152
+oid sha256:332a2885cc2b1f7d544fb0148eaab4a7ecae4ff4d00d9aba13e3113295b2dee4
+size 2519888


### PR DESCRIPTION
Should fix the collision issues noticed by testers on Minkata shards.
Testers were able to glitch through collisions on the front part of the elevator when it was rising up

[Scene Object - Elevator Wall] Coordinate Interface removed.
[Coordinate Interface - SubWorld_New] Scene Object "Elevator Wall" removed from Children
[Generic Physical - Elevator Wall] Bottom face removed. Angled and moved to bottom section of elevator shaft.