### PR TITLE
Updated Bahro Book image with corrected Yeesha symbol

### DIFF
--- a/compiled/dat/GUI_District_bkBahroRockBook.prp
+++ b/compiled/dat/GUI_District_bkBahroRockBook.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f14a67caf064ed3098594ac7abbade8c6b2f89e2c753eeb63b16745ecbe9a0d0
-size 2053962
+oid sha256:7415268e833d833c165f3b574c43331715e70cc432225692d3def207f248fb2a
+size 2053974

--- a/sources/textures/tga/GUI/xBahroPageRock_Original.tga
+++ b/sources/textures/tga/GUI/xBahroPageRock_Original.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3030e6a6260504ac9498086631349f673a9cc565b85056a42e92dfef51000935
+size 2776758

--- a/sources/textures/tga/GUI/xBahroPageRock_v3d.tga
+++ b/sources/textures/tga/GUI/xBahroPageRock_v3d.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:942972b86050e5af9ece25a7147ccfdc34a7a6a032eb40a977f85c24c95fc3df
+size 3557723


### PR DESCRIPTION
CalumTraveler gave the Yeesha Symbol on the bahro stone the correct aspect and colorized it to match the original.

Original
![image](https://user-images.githubusercontent.com/416114/127099373-8206543c-6e34-4801-90f8-1114919b79de.png)

New Version
![image](https://user-images.githubusercontent.com/416114/127099388-3a17a2ec-ba95-41aa-972b-1caf3088afa3.png)
