### PR TITLE
Fixes for Ercana Canyon

### DIFF
--- a/compiled/dat/Ercana_District_Canyon.prp
+++ b/compiled/dat/Ercana_District_Canyon.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a1b42290f9265c68271dc9f656bc8e8ad05580483faa2d611e96aa0b7054986
-size 4626636
+oid sha256:a0d3cad8e8504880a8794929e9e93b03d240aacbeba45369141c43e5802caa6a
+size 4710104

--- a/compiled/dat/Ercana_District_PlantExterior01.prp
+++ b/compiled/dat/Ercana_District_PlantExterior01.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:15f36232c6924f499aff5e8900de4da6fd2ec84c44c36649998dce6413cb3267
-size 4953108
+oid sha256:22e5d63f0ab96f7afe216de7d969b2d9bf9959a3b27a5118232dd75819170ad6
+size 4792534

--- a/compiled/dat/Ercana_District_Tunnel.prp
+++ b/compiled/dat/Ercana_District_Tunnel.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:918e2a997669de292aa3a1e0745577c9835dfed3f6b3e89e028551ba0259541f
-size 1418470
+oid sha256:efe41c641a315588a4ac9179d83ad64feea31a3897a33053498a47bc4ae4d0f3
+size 1461555


### PR DESCRIPTION
This is a collection of graphical fixes to Er'cana age.
All prps were resaved to fix any graphic issues due to textures locs possibly changing.

Canyon
Harvester cable next to ladder attached to nothing
Floating rocks and bushes under car ramp
Harvester call button floats
Spout on harvester clips through wings when harvester is moving away and cart is inside facility
See through area on harvester console
Journey cloth beside the harvester was floating
Z-flighting rocks near sinkhole and end of the line
Large Plants floating

Tunnel
Lights at top of car ramp have no view face modifier
All the lights in left tunnel are in wrong spot
2 top lights in right tunnel are gone
See out into world in between cart tunnels walkways
        
PlantExterior01
Water Tunnel doors need collisions when open