### PR TITLE
Additional Graphical Fixes for Ercana

### DIFF
--- a/compiled/dat/Ercana_District_Canyon.prp
+++ b/compiled/dat/Ercana_District_Canyon.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a0d3cad8e8504880a8794929e9e93b03d240aacbeba45369141c43e5802caa6a
-size 4710104
+oid sha256:203a05b8033debc00f48187e5895df66ce1fa911c054e5fc9c9250141a3dc0dd
+size 4712101


### PR DESCRIPTION
The warning light on the harvester console was not lit correctly.
Old 
![image](https://user-images.githubusercontent.com/416114/135153462-dc0a9b74-42cc-4c45-b797-b4f2dfd194c0.png)
New 
![image](https://user-images.githubusercontent.com/416114/135153843-2a5d55bc-72cc-4a1a-9e68-a583b41f4ba0.png)


The harvester Railing had a few stretched and z-fighting textures and a few sections that the normals were flipped. The end caps for the railing near the ladder were also missing.
Old
![image](https://user-images.githubusercontent.com/416114/135153599-2352e635-bd86-46f9-be83-9db39fd8308c.png)
![image](https://user-images.githubusercontent.com/416114/135153648-188c7aeb-5186-4f97-98c8-5d232567692f.png)
![image](https://user-images.githubusercontent.com/416114/135153914-52ccafca-d3fc-4dad-b103-a121a384bd1b.png)
New
![image](https://user-images.githubusercontent.com/416114/135154172-e98d611d-f8e1-46ff-ae6a-7911afa8c108.png)
![image](https://user-images.githubusercontent.com/416114/135154082-53869129-81d7-4295-8970-3364cc292b30.png)
![image](https://user-images.githubusercontent.com/416114/135154235-36816a3e-2fbf-4dc2-8b42-8ffaf1d4e9a3.png)
