### PR TITLE
Prevents Bahro Stones in Kirel Egg room from working

### DIFF
--- a/compiled/dat/Neighborhood02_District_krelPrivateRm.prp
+++ b/compiled/dat/Neighborhood02_District_krelPrivateRm.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2523e767625e97461aca80528cdb7e0e9c985a2911bf73f1d58ff62dcfaf139
-size 1500815
+oid sha256:aea1c48d85ac866ddbbb9761b122b4492ba42c15bbd2a9006eb5cc1b2ded4ee4
+size 1416032


### PR DESCRIPTION
This change is to prevent the use of the Bahro Stones inside the Kirel Egg Room.
It is normally impossible to reach these Bahro Stones in normal play, but if they are reached and used it will mess up the players accounts.

Doing this prevents that from happening.