### PR TITLE
Negilahn Journal cover missing

### DIFF
--- a/compiled/dat/CityEnglish.loc
+++ b/compiled/dat/CityEnglish.loc
@@ -1366,7 +1366,7 @@ Probably ready for a Dr. Watson review.
 ]]></translation>
 			</element>
 			<element name="Negilahn">
-				<translation language="English"><![CDATA[<cover src="xKIJournalCover*1#0.hsm"><font size=10 face=courier color=000000><margin left=62 right=62 top=62 bottom=48><p align=center>
+				<translation language="English"><![CDATA[<cover src="xnegilahninfojournalcover*0#0.hsm"><font size=10 face=courier color=000000><margin left=62 right=62 top=62 bottom=48><p align=center>
 
 <p align=left>Taken from D'ni Negilahn Introduction Pamphlet
 Translated by Tricia Lawson 11.20.03

--- a/compiled/dat/CityFrench.loc
+++ b/compiled/dat/CityFrench.loc
@@ -1288,7 +1288,7 @@ Il va sans doute falloir que le Dr Watson revoie ce texte.
 			<element name="MinkataQuestJournal">
 			</element>
 			<element name="Negilahn">
-				<translation language="French"><![CDATA[<cover src="xKIJournalCover*1#0.hsm"><font size=10 face=courier color=000000><margin left=62 right=62 top=62 bottom=48><p align=center>
+				<translation language="French"><![CDATA[<cover src="xnegilahninfojournalcover*0#0.hsm"><font size=10 face=courier color=000000><margin left=62 right=62 top=62 bottom=48><p align=center>
 
 <p align=left>Extrait de l'introduction sur le Negilahn de D'ni
 Traduit par by Tricia Lawson 20.11.03

--- a/compiled/dat/CityGerman.loc
+++ b/compiled/dat/CityGerman.loc
@@ -1326,7 +1326,7 @@ Bereit zur Vorlage für die Prüfung durch Dr. Watson]]></translation>
 			<element name="MinkataQuestJournal">
 			</element>
 			<element name="Negilahn">
-				<translation language="German"><![CDATA[<cover src="xKIJournalCover*1#0.hsm"><font size=10 face=courier color=000000><margin left=62 right=62 top=62 bottom=48><p align=center>
+				<translation language="German"><![CDATA[<cover src="xnegilahninfojournalcover*0#0.hsm"><font size=10 face=courier color=000000><margin left=62 right=62 top=62 bottom=48><p align=center>
 
 <p align=left>Auszug aus der D'ni-Einführungsnotiz für Negilahn
 Übersetzt von Tricia Lawson 20.11.03

--- a/compiled/dat/GUI_District_BkBookImages.prp
+++ b/compiled/dat/GUI_District_BkBookImages.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e1bf2569dda4d9cfc4ab26032ca4f66c4d7379b2594519c5045aad20c6924a0
-size 7714052
+oid sha256:a2061120cc4920f4ea3964b8d9ef71a294c4f061e420db3efcec8e743c73c51f
+size 8413289


### PR DESCRIPTION
The Negilahn journal cover inside city museum shows Ki journal when you click on it.

This fixes that issue.

Conflicts with PR #65 