### PR TITLE
Fix Quab footsteps

### DIFF
--- a/compiled/dat/CustomAvatars_District_Quab.prp
+++ b/compiled/dat/CustomAvatars_District_Quab.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0f6be97f9c6d68beeccf7faf68dda7a48510ea26f5109eaa365100f08c22b2b3
-size 136890
+oid sha256:8d14c382bf10e425a99c154cbbe833aba98f45590f6c556c70dbe66320d8c6f1
+size 136921


### PR DESCRIPTION
This ensures that the Armature Effects object for the Quab footsteps has the correct RandomSoundMod set up for the "Stone" surface, not just the "Dirt" surface.