### PR TITLE
Improve text resolution of BaronCityOffice Marie note

### DIFF
--- a/compiled/dat/BaronCityOffice_District_BCOWrinkledPaper.prp
+++ b/compiled/dat/BaronCityOffice_District_BCOWrinkledPaper.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b8e730bb442d241498517ae2c1a43e3bfb7ec7ff67e4de4d641214e5430b695d
+oid sha256:d557c5422e2cd780a9776af9263d34720f3ef5e8840a699bd19277dc27b565c8
 size 8242


### PR DESCRIPTION
On Marie's note in the Baron City Office ("The house on Noloben is NOT empty."), the text is visibly pixelated, especially at higher resolutions.

This PR doubles the resolution of the dynamic text map for the note. Together with a Python change to also double the font size (H-uru/Plasma#1008), this makes the text sharper without changing its size.

<details>
<summary>Screenshots for comparison</summary>

![Note, crunchy](https://user-images.githubusercontent.com/6641959/139125707-fc6e7a33-4a0e-432c-9eba-0b025b007249.png)

![Note, no longer crunchy](https://user-images.githubusercontent.com/6641959/139125760-0b873a39-08d0-4543-a891-268e8cc503bc.png)
</details>

I noticed that with the doubled font size, the writing is now slightly wider. It seems that higher sizes of the Michelle font have wider letters or more horizontal spacing (relative to the font size). I don't know if there's a good way to work around this. But in normal gameplay, it's not very noticeable IMO - the text still fits well onto the note, just the right margin is a bit narrower.