### PR TITLE
Restore missing footnote in King Kerath notebook

### DIFF
--- a/compiled/dat/CityEnglish.loc
+++ b/compiled/dat/CityEnglish.loc
@@ -579,7 +579,7 @@ Kedri eventually passed away in 3903 at the age of 329, leaving the throne to hi
 
 His mother had raised him to follow the teachings of Gish and by the time he took the throne he was believed to be a whole-hearted believer in the Followers. Because of that, and the experience of watching his father interact with his advisors, Kerath had decided from an early age that a King was no longer the correct way that D'ni should be led. At least, he argued, not until the true Great King would come. 
 
-The fact that Kerath, in a single reign, was able to convince his people that the way they had been ruled for thousands of years was wrong and should be changed, should be considered nothing short of miraculous. Kerath carefully crafted his arguments as a benefit for the Guilds more than anything else. After all, he argued, "D'ni is the Guilds…let us be protected by their fortress and be ruled by their wisdom."  
+The fact that Kerath, in a single reign, was able to convince his people that the way they had been ruled for thousands of years was wrong and should be changed, should be considered nothing short of miraculous. Kerath carefully crafted his arguments as a benefit for the Guilds more than anything else. After all, he argued, "D'ni is the Guilds…let us be protected by their fortress and be ruled by their wisdom."*  
 
 It was hard for the Guilds not to support a proposal that removed the King from the highest authority and replaced him with Five Lords, Lords that would be automatically chosen from the Grand Masters of the Guilds. It gave all of the power of D'ni to the Guilds and there were only a few Grand Masters who seemed to disagree. Those few were known as faithful followers of the Great King, and Ri'neref, who had always supported the role of Kings. 
 
@@ -601,6 +601,8 @@ The time of the Kings was over.
 * Taken from Kerath's public speech in which he first proposed the idea
 
 * From "The First Five" written by Tarvis in 7000
+
+* From "How They Came; A Detailed Look at what started the Mee-Dis War" by Jamen. Written in 7201
 ]]></translation>
 			</element>
 			<element name="KingKoreen">

--- a/compiled/dat/CityFrench.loc
+++ b/compiled/dat/CityFrench.loc
@@ -520,7 +520,7 @@ Kedri mourut en 3903 à l'âge de 329 ans et légua le trône à son fils aîné
 
 Sa mère lui appris les enseignements de Gish, si bien qu'au moment où il monta sur le trône, on le prenait pour un adorateur des Partisans. Suite à ça et fort de l'expérience procurée par les interactions entre son père et ses conseillers, Kerath décida très jeune que la monarchie n'était plus le meilleur système de gouvernement pour D'ni. Et il décida qu'il en serait ainsi, au moins jusqu'à l'arrivée du Grand Roi. 
 
-Et le fait que Kerath, au cours de son seul règne, parvint à convaincre son peuple que la façon dont il a été gouverné pendant des milliers d'années était mauvaise et qu'il fallait tout changer, tient vraiment du miracle. Kerath choisissait prudemment ses arguments, mettant l'accent sur les négociations avec les Guildes. Après tout, disait-il, « D'ni repose sur les Guildes... acceptons la protection de leurs forteresses et les conseils de leur sagesse. »  
+Et le fait que Kerath, au cours de son seul règne, parvint à convaincre son peuple que la façon dont il a été gouverné pendant des milliers d'années était mauvaise et qu'il fallait tout changer, tient vraiment du miracle. Kerath choisissait prudemment ses arguments, mettant l'accent sur les négociations avec les Guildes. Après tout, disait-il, « D'ni repose sur les Guildes... acceptons la protection de leurs forteresses et les conseils de leur sagesse. »*  
 
 Il était dur pour les Guildes de ne pas accepter une proposition qui suggérait le remplacement du roi, suprême autorité, par Cinq seigneurs. Ces seigneurs seraient choisis par les Grands maîtres des Guildes. Il donnait tout le pouvoir de D'ni aux Guildes. Peu de Grands maîtres semblaient contre l'idée. Pourtant, quelques loyaux partisans du Grand Roi, et Ri'neref, qui avait toujours soutenu le rôle des rois, se plaignirent. 
 
@@ -542,6 +542,8 @@ Le temps des Rois était révolu.
 * Extrait d'un discours public de Kerath au cours duquel il proposa l'idée pour la première fois
 
 * Tiré de « Les Cinq premiers »; écrit par Tarvis en 7000
+
+* Extrait de "La vérité sur le début de la Guerre de Mee-Dis" de Jamen. Écrit en 7201
 ]]></translation>
 			</element>
 			<element name="KingKoreen">

--- a/compiled/dat/CityGerman.loc
+++ b/compiled/dat/CityGerman.loc
@@ -541,11 +541,11 @@ Kedri starb schließlich im Jahre 3903 im Alter von 329 Jahren und hinterließ d
 
 Seine Mutter erzog ihn im Glauben des Gish und man geht davon aus, dass er zur Zeit seiner Thronbesteigung ein Gläubiger der Anhänger war. Dadurch und dadurch, dass er seinen Vater im Umgang mit seinen Beratern beobachtet hat, beschloss Kerath schon früh, dass ein König nicht die richtige Art sei, die D'ni zu führen. Zumindest nicht so lange, bis der wahre Große König käme. 
 
-Es grenzt schon an ein Wunder, dass es Kerath während seiner Regentschaft gelang, sein Volk davon zu überzeugen, dass die Art und Weise, wie sie Tausende von Jahren lang regiert worden waren, falsch sei und geändert werden müsse. Kerath wählte seine Argumente weise und so geschah es vor allem zum Nutzen der Gilden. Schließlich, so argumentierte er, 'sind die D'ni die Gilden ... lasst ihre Festung uns als Schutz dienen und durch ihre Weisheit regiert werden.'
+Es grenzt schon an ein Wunder, dass es Kerath während seiner Regentschaft gelang, sein Volk davon zu überzeugen, dass die Art und Weise, wie sie Tausende von Jahren lang regiert worden waren, falsch sei und geändert werden müsse. Kerath wählte seine Argumente weise und so geschah es vor allem zum Nutzen der Gilden. Schließlich, so argumentierte er, 'sind die D'ni die Gilden ... lasst ihre Festung uns als Schutz dienen und durch ihre Weisheit regiert werden.'*
 
 Es war schwer für die Gilden, einen solchen Vorschlag nicht zu unterstützen, der anstelle des Königs als oberste Autorität fünf Fürsten vorsah, Fürsten, die automatisch von den Großmeistern der Gilden gewählt werden würden. Dadurch wurde die gesamte Macht der D'ni in die Hände der Gilden gelegt und es gab scheinbar nur wenige Großmeister, die dem Vorschlag nicht zustimmten. Diese wenigen waren als treue Anhänger des Großen Königs und Ri'nerefs bekannt, der schon immer die Rolle des Königs unterstützt hatte. 
 
-Es war ein glücklicher Umstand für Kerath, dass - obwohl sein Volk an verschiedene philosphische Ideologien glaubte - nur diejenigen der Gedanke der Abschaffung des Königs störte, die treu den Originallehren des Ri'neref und Großen Königs folgten. Und der Großteil der D'ni folgte nicht diesen Lehren, sondern denen des Nemiy, Gish, des Wächters und verschiedenen anderen. Das Ergebnis war, dass das Volk einen kulturellen Druck aushalten musste und keinen religiösen. 
+Es war ein glücklicher Umstand für Kerath, dass - obwohl sein Volk an verschiedene philosphische Ideologien glaubte - nur diejenigen der Gedanke der Abschaffung des Königs störte, die treu den Originallehren des Ri'neref und Großen Königs folgten. Und der Großteil der D'ni folgte nicht diesen Lehren, sondern denen des Nemiy, Gish, des Wächters und verschiedenen anderen. Das Ergebnis war, dass das Volk einen kulturellen Druck aushalten musste und keinen religiösen*. 
 
 In dem Versuch, die Gilden noch mehr zufrieden zu stellen, schlug Kerath vor, das Gebäude der Ratskammer zu renovieren und neue Räume anzubauen sowie eine neue Gildenhalle zu bauen, die Ausdruck ihrer neuen Macht sein sollte. Ein Symbol der neuen Macht der Gilden und Fürsten und eine weitere Verunglimpfung des Großen Königs, wodurch das Gedenken an ihn noch weiter unter Regierungsgebäuden begraben werden würde. 
 
@@ -563,6 +563,8 @@ Die Zeit der Könige hatte ein Ende gefunden.
 * Auszug aus der öffentlichen Rede Keraths, in der er zum ersten Mal seine Idee vorstellte
 
 * Aus 'Die Ersten Fünf', geschrieben von Tarvis im Jahre 7000
+
+* Aus "Wie sie gekommen sind - eine detaillierte Analyse der Hintergründe des Mee-Dis-Kriegs." von Jamen, geschrieben 7201
 ]]></translation>
 			</element>
 			<element name="KingKoreen">


### PR DESCRIPTION
Based on [a pre-release version of the King Kerath notebook](https://archive.guildofarchivists.org/wiki/Reference:DRC_research_notebooks/King_Kerath/2002_DPWR_transcription) that was preserved by the Guild of Archivists (formerly DPWR), the footnotes were slightly changed at some point during development (before the release of ABM). In particular, the first asterisk (next to a Kerath quote) was removed from the text, and the third footnote entry (referencing a Mee-Dis War book) was removed from the footnotes.

It appears that these changes were accidental. The removed asterisk doesn't match the removed footnote, and the remaining asterisks and footnotes no longer match up very well with each other. This is most noticeable with the "Taken from Kerath's public speech" footnote: in the pre-release version, it matches up with a Kerath quote, but in the release version, it corresponds to a paragraph about D'ni prophets that doesn't contain anything said by Kerath.

This commit re-adds the previously removed asterisk and Mee-Dis War footnote, which restores the footnotes to the more consistent pre-release state. The French and German translations are updated accordingly, with the translation of the footnote copied from other notebooks. The Italian and Spanish translations are *not* updated in this commit, because they are incomplete and don't contain a translation of the Mee-Dis War footnote anywhere.

I'm going to ping the Lore Team on the OpenUru Discord, so that they can look over this and check my reasoning, so that I don't rewrite history in a bad way.