### PR TITLE
Fix sentence containing percent symbol in King Hemelin notebook

### DIFF
--- a/compiled/dat/CityEnglish.loc
+++ b/compiled/dat/CityEnglish.loc
@@ -395,7 +395,7 @@ Hemelin left an upbeat, but "rather dazed"* culture to his successor when he pas
 
 
 * From "The Healing of D'ni" written by Manesah in 2294
-* Though others did live through the illness, Healer records indicate a disease reached its later stages
+* Though others did live through the illness, Healer records indicate a 95% fatality rate once the disease reached its later stages
 * A drink was developed that prevented the body from contracting the illness even when directly exposed
 * From "The Healing of D'ni" written by Manesah in 2294
 * As a result, the day became a day often chosen for marriage in later years. 

--- a/compiled/dat/CityFrench.loc
+++ b/compiled/dat/CityFrench.loc
@@ -339,7 +339,7 @@ Lorsqu'il mourut en 2356 à l'âge de 342 ans, Hemelin laissa une culture optimi
 
 
 * Extrait de "La guérison de D'ni" de Manesah, 2294.
-* D'autres ont aussi survécu à cette maladie, mais selon les Soigneurs, le taux de mortalité était de 95 %256sque la maladie atteignait ses stades finaux.
+* D'autres ont aussi survécu à cette maladie, mais selon les Soigneurs, le taux de mortalité était de 95 % lorsque la maladie atteignait ses stades finaux.
 * Ils développèrent une potion qui empêchait le corps de contracter cette maladie même en y étant directement exposé.
 * Extrait de "La guérison de D'ni" de Manesah, 2294.
 * Par conséquent, ce jour-là fut fréquemment choisi pour les mariages dans les années qui suivirent.

--- a/compiled/dat/CityGerman.loc
+++ b/compiled/dat/CityGerman.loc
@@ -347,7 +347,7 @@ Hemelin hinterließ seinem Nachfolger eine optimistische, aber "ziemlich benomme
 
 * Aus "Die Heilung der D'ni", geschrieben von Manesah 2294.
 
-* Obwohl auch andere die Krankheit überlebten, weisen die Aufzeichnungen der Heiler auf eine Sterblichkeitsrate von 95%256s die Krankheit in die späteren Stadien eingetreten war.
+* Obwohl auch andere die Krankheit überlebten, weisen die Aufzeichnungen der Heiler auf eine Sterblichkeitsrate von 95% hin, als die Krankheit in die späteren Stadien eingetreten war.
 
 * Ein Getränk wurde entwickelt, das den Körper selbst bei direktem Kontakt vor der Krankheit schütze.
 


### PR DESCRIPTION
One sentence in the King Hemelin notebook was partially destroyed at some point, apparently as the result of a regex replace gone wrong. Someone replaced "%.*s" with "%256s", probably meaning to adjust some printf-style format strings, but this accidentally also matched a literal percent symbol in the King Hemelin notebook and deleted some of the following words.

In the English version, someone apparently noticed this and removed the destroyed part of the sentence, but did not fully undo the incorrect change. The French and German translations were never fixed.

This commit fully restores the sentence, based on the text from Uru CC, where it was not yet broken. The English original and French and German translations are fixed (there is no Italian or Spanish translation for this notebook).