### PR TITLE
Fix percent symbol in King Hemelin notebook, for real this time

### DIFF
--- a/compiled/dat/CityEnglish.loc
+++ b/compiled/dat/CityEnglish.loc
@@ -395,7 +395,7 @@ Hemelin left an upbeat, but "rather dazed"* culture to his successor when he pas
 
 
 * From "The Healing of D'ni" written by Manesah in 2294
-* Though others did live through the illness, Healer records indicate a 95% fatality rate once the disease reached its later stages
+* Though others did live through the illness, Healer records indicate a 95\% fatality rate once the disease reached its later stages
 * A drink was developed that prevented the body from contracting the illness even when directly exposed
 * From "The Healing of D'ni" written by Manesah in 2294
 * As a result, the day became a day often chosen for marriage in later years. 

--- a/compiled/dat/CityFrench.loc
+++ b/compiled/dat/CityFrench.loc
@@ -339,7 +339,7 @@ Lorsqu'il mourut en 2356 à l'âge de 342 ans, Hemelin laissa une culture optimi
 
 
 * Extrait de "La guérison de D'ni" de Manesah, 2294.
-* D'autres ont aussi survécu à cette maladie, mais selon les Soigneurs, le taux de mortalité était de 95 % lorsque la maladie atteignait ses stades finaux.
+* D'autres ont aussi survécu à cette maladie, mais selon les Soigneurs, le taux de mortalité était de 95 \% lorsque la maladie atteignait ses stades finaux.
 * Ils développèrent une potion qui empêchait le corps de contracter cette maladie même en y étant directement exposé.
 * Extrait de "La guérison de D'ni" de Manesah, 2294.
 * Par conséquent, ce jour-là fut fréquemment choisi pour les mariages dans les années qui suivirent.

--- a/compiled/dat/CityGerman.loc
+++ b/compiled/dat/CityGerman.loc
@@ -347,7 +347,7 @@ Hemelin hinterließ seinem Nachfolger eine optimistische, aber "ziemlich benomme
 
 * Aus "Die Heilung der D'ni", geschrieben von Manesah 2294.
 
-* Obwohl auch andere die Krankheit überlebten, weisen die Aufzeichnungen der Heiler auf eine Sterblichkeitsrate von 95% hin, als die Krankheit in die späteren Stadien eingetreten war.
+* Obwohl auch andere die Krankheit überlebten, weisen die Aufzeichnungen der Heiler auf eine Sterblichkeitsrate von 95\% hin, als die Krankheit in die späteren Stadien eingetreten war.
 
 * Ein Getränk wurde entwickelt, das den Körper selbst bei direktem Kontakt vor der Krankheit schütze.
 


### PR DESCRIPTION
A fix for my attempted fix #88, which I apparently tested very badly - those changes actually break the journal's content and formatting.

The problem is that the localization system *always* tries to interpret placeholders (e. g. %1) in translations, even if it's just constant text that's not supposed to have placeholders. To display the percent symbols here literally, they need to be escaped (using a backslash, counter-intuitively).

And yes, this time I did test the changes properly 🙂

![Actually fixed journal text](https://user-images.githubusercontent.com/6641959/139949366-5e152705-0d6d-46aa-a446-ee34ad116f85.png)