### PR TITLE
Re-alphabetize and add missing empty elements for KI LOCs

### DIFF
--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -183,11 +183,11 @@
 			<element name="ChangePassword">
 				<translation language="English">/changepassword</translation>
 			</element>
-			<element name="ChatAllAge">
-				<translation language="English">/shout</translation>
-			</element>
 			<element name="ChatAge">
 				<translation language="English">/age</translation>
+			</element>
+			<element name="ChatAllAge">
+				<translation language="English">/shout</translation>
 			</element>
 			<element name="ChatBuddies">
 				<translation language="English">/buddies</translation>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -172,11 +172,11 @@
 			</element>
 			<element name="ChangePassword">
 			</element>
-			<element name="ChatAllAge">
-				<translation language="French">/crier</translation>
-			</element>
 			<element name="ChatAge">
 				<translation language="French">/âge</translation>
+			</element>
+			<element name="ChatAllAge">
+				<translation language="French">/crier</translation>
 			</element>
 			<element name="ChatBuddies">
 				<translation language="French">/amis</translation>
@@ -1022,6 +1022,8 @@ souhaitez-vous jouer ?</translation>
 			<element name="LogDumpFailed">
 			</element>
 			<element name="LogDumpSuccess">
+			</element>
+			<element name="NewClothing">
 			</element>
 			<element name="NexusLinkAdded">
 				<translation language="French">Un lien a été ajouté a votre Nexus</translation>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -172,11 +172,11 @@
 			</element>
 			<element name="ChangePassword">
 			</element>
-			<element name="ChatAllAge">
-				<translation language="German">/schreien</translation>
-			</element>
 			<element name="ChatAge">
 				<translation language="German">/welt</translation>
+			</element>
+			<element name="ChatAllAge">
+				<translation language="German">/schreien</translation>
 			</element>
 			<element name="ChatBuddies">
 				<translation language="German">/freunde</translation>
@@ -1024,6 +1024,8 @@ Wollen Sie mitspielen?</translation>
 			<element name="LogDumpFailed">
 			</element>
 			<element name="LogDumpSuccess">
+			</element>
+			<element name="NewClothing">
 			</element>
 			<element name="NexusLinkAdded">
 				<translation language="German">Ein link wurde zu ihrer KI zugeführt.</translation>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -166,11 +166,11 @@
 			</element>
 			<element name="ChangePassword">
 			</element>
-			<element name="ChatAllAge">
-				<translation language="Italian">/shout</translation>
-			</element>
 			<element name="ChatAge">
 				<translation language="Italian">/età</translation>
+			</element>
+			<element name="ChatAllAge">
+				<translation language="Italian">/shout</translation>
 			</element>
 			<element name="ChatBuddies">
 				<translation language="Italian">/amici</translation>
@@ -952,6 +952,8 @@ Vuoi giocare?</translation>
 			<element name="LogDumpFailed">
 			</element>
 			<element name="LogDumpSuccess">
+			</element>
+			<element name="NewClothing">
 			</element>
 			<element name="NexusLinkAdded">
 			</element>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -166,11 +166,11 @@
 			</element>
 			<element name="ChangePassword">
 			</element>
-			<element name="ChatAllAge">
-				<translation language="Spanish">/grito</translation>
-			</element>
 			<element name="ChatAge">
 				<translation language="Spanish">/era</translation>
+			</element>
+			<element name="ChatAllAge">
+				<translation language="Spanish">/grito</translation>
 			</element>
 			<element name="ChatBuddies">
 				<translation language="Spanish">/amigos</translation>
@@ -951,6 +951,8 @@ Firmado,
 			<element name="LogDumpFailed">
 			</element>
 			<element name="LogDumpSuccess">
+			</element>
+			<element name="NewClothing">
 			</element>
 			<element name="NexusLinkAdded">
 			</element>


### PR DESCRIPTION
Flipped the LOC files through plLocalizationEditor with these results. Fixes bad alphabetization I did when adding ChatAge command by hand to the LOCs and adds empty NewClothing message element to all the non-English KI LOC files.