### PR TITLE
Fix nexus KI slot regions in City

### DIFF
--- a/compiled/dat/city_District_canyon.prp
+++ b/compiled/dat/city_District_canyon.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9c8208090d26c5cb3d640f344c0f8f199d26cbe60edff2c0d7c68cd638325b2
-size 2999513
+oid sha256:9bbca35676fc298c0f45a0accd18b1e86e35ca2d8a66b8db79ba3a950a544fd9
+size 2999737

--- a/compiled/dat/city_District_courtyard.prp
+++ b/compiled/dat/city_District_courtyard.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:256ea6f05c54ca57f25348d98a3e12b670e12d5eadb08a297fd667cfb6cace59
+oid sha256:0400bbcce9ff96e2212928f6fd6b1e95f3240bfc88b89299ed24a0b929bbb937
 size 2793132

--- a/compiled/dat/city_District_ferry.prp
+++ b/compiled/dat/city_District_ferry.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:769f4b2c70301fec00648694dae0c88fbccf0b3f787f10e197b6c926953a089e
+oid sha256:df8385952267ebf18885b3b09f676e57b12807cc87ebe09086177c44fbb3dee9
 size 3004423

--- a/compiled/dat/city_District_palace.prp
+++ b/compiled/dat/city_District_palace.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:93240fe856a8c6971cc5a2368e5b634b51673730bf24264268d00f2f1d78cf25
-size 2904330
+oid sha256:acf0fe2567ef97a41a635bd0055a9b23d2b0c39dca08d7ba4a6cfa2fc3ba42c1
+size 2823272


### PR DESCRIPTION
Resolves H-uru/moul-assets#107

Nexus Book and Ki Slot regions had a number of issues.

Fixed so you can always click the left side and it will add the link to you nexus.
Clicking on book will open the book.