### PR TITLE
Add single subtitle file for Zandi's Cleft intro as a testing sample

### DIFF
--- a/compiled/sfx/clftZandiOpen01a_eng.sub
+++ b/compiled/sfx/clftZandiOpen01a_eng.sub
@@ -1,0 +1,27 @@
+1
+00:00:00,100 --> 00:00:05,800
+Zandi: Hey. Welcome. So, uh, I'm Zandi.
+
+2
+00:00:06,700 --> 00:00:08,900
+Zandi: I probably know more about why you're here than you do.
+
+3
+00:00:09,400 --> 00:00:14,500
+Zandi: (chuckles) Don't worry about it. You felt drawn here, just like the others.
+
+4
+00:00:15,000 --> 00:00:21,900
+Zandi: I- I'm not really here to give you answers, just to give you help. Get you started.
+
+5
+00:00:23,100 --> 00:00:25,700
+Zandi: She's left a message for you in the Cleft.
+
+6
+00:00:27,100 --> 00:00:36,800
+Zandi: Listen to it well. Follow her. Find the Journeys. And then... enter the tree.
+
+7
+00:00:38,600 --> 00:00:41,600
+Zandi: Oh, and uh, check with me if you need help.


### PR DESCRIPTION
Adding single subtitle file (easy to test with new character) as a sample to test the new feature. I was promised bonus points by Adam:

> I think there would be bonus points for breaking up the .sub PR into a single "demonstration" subtitle PR to go along with the core functionality and a larger one with the bulk load of the .subs. That way we can merge the functionality itself rather quickly and take time glancing over the subtitles themselves.