### PR TITLE
Missing python file mod for pine tree collider

### DIFF
--- a/compiled/dat/Personal_District_psnlMYSTII.prp
+++ b/compiled/dat/Personal_District_psnlMYSTII.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61ab242ae2d0d24cd4eaa63b40ca8077ef2e8f7f2c8d12d8fb8a10e6a03bc3ac
-size 8591279
+oid sha256:14b89aa77b4b0685ae4ce4ffbf75422407c929119c4d3cabb4f6b6132e3a31d1
+size 8591326


### PR DESCRIPTION
There was a collider for one of the pine trees between the bench and bahro pole.
When you turned on the autumn page it would hide the pine tree, but not the collider box around that tree.