### PR TITLE
Fix GZ Beam in city

### DIFF
--- a/compiled/dat/city_District_harbor.prp
+++ b/compiled/dat/city_District_harbor.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:acdb70571c3c8f6efdca72755178d868c4bea4b418f1c11a270303213d9553ec
-size 969661
+oid sha256:9b848ee29a7e362a4abdfe82c38ff0c2a652a9455d2b9e2fe808bc12985e1506
+size 968061


### PR DESCRIPTION
GZ beam animation end point is past its start point.
This give the impression that the GZ beam is skipping backwards when it gets to the arch.

Adjusted the end point so it better meets the start point.