### PR TITLE
Remove Visitor selection from Character selection screen

### DIFF
--- a/compiled/dat/GUI_District_GUIDialog04b.prp
+++ b/compiled/dat/GUI_District_GUIDialog04b.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b37f1619abdb3c157f18ff9a1be0cf782472ae55599d28476a86082131ff30c
-size 91331
+oid sha256:8eb1a23709725ae8738341cf066f94ad05b810a44ff5618fa11e2bfc6fd3bd5f
+size 92105

--- a/compiled/dat/GUI_District_GUIDialog04b.prp
+++ b/compiled/dat/GUI_District_GUIDialog04b.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8eb1a23709725ae8738341cf066f94ad05b810a44ff5618fa11e2bfc6fd3bd5f
-size 92105
+oid sha256:312e681caa4eb2b1010327a769d13aea4cad75578d3f8b1622d807915d5206e3
+size 101081


### PR DESCRIPTION
Moves all the Visitor elements off screen and shrinks the space freed up from doing that

![image](https://user-images.githubusercontent.com/416114/158936172-1a706ad1-1ef1-4cf3-ba2f-a9e6994a2b48.png)
