### PR TITLE
Adds the cyan camera work done to create the trailer for Myst Online

### DIFF
--- a/compiled/dat/Cleft_District_trailerCamPage.prp
+++ b/compiled/dat/Cleft_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a979af9e1b1577a5dfe0ac9f88da1bbe7f888e38bdb2740a1614ed9cbf7c913
+size 361370

--- a/compiled/dat/Cleft_District_trailerCamPage.prp
+++ b/compiled/dat/Cleft_District_trailerCamPage.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9a979af9e1b1577a5dfe0ac9f88da1bbe7f888e38bdb2740a1614ed9cbf7c913
-size 361370
+oid sha256:f702d6e97ce2208eeb8aaac587e7c7a570cd13618be28f90339244898bd86baf
+size 360207


### PR DESCRIPTION
This is the cleft camera flyby done in this trailer for Myst Online
https://www.youtube.com/watch?v=rLvkMJDrMAU

Clip of how I set up to trigger the camera and the flybys
https://www.youtube.com/watch?v=8An_EP3jVfk

This PRP will never load in any game due to the age file having the page set to be controlled by page loading.
Inside the age file Line 35
`Page=trailerCamPage,18,1`
needs to be changed to load the file
`Page=trailerCamPage,18`