### PR TITLE
Add /textcolor command and supporting text elements

### DIFF
--- a/compiled/dat/GlobalEnglish.loc
+++ b/compiled/dat/GlobalEnglish.loc
@@ -68,7 +68,7 @@
 				<translation language="English">darkgreen</translation>
 			</element>
 			<element name="DarkPurple">
-				<translation language="English">darkpurple</translation>
+				<translation language="English">purple</translation>
 			</element>
 			<element name="Gray">
 				<translation language="English">gray</translation>

--- a/compiled/dat/GlobalEnglish.loc
+++ b/compiled/dat/GlobalEnglish.loc
@@ -48,6 +48,68 @@
 				<translation language="English">Tokotah Alley</translation>
 			</element>
 		</set>
+		<set name="Colors">
+			<element name="Black">
+				<translation language="English">black</translation>
+			</element>
+			<element name="Blue">
+				<translation language="English">blue</translation>
+			</element>
+			<element name="Brown">
+				<translation language="English">brown</translation>
+			</element>
+			<element name="Cyan">
+				<translation language="English">cyan</translation>
+			</element>
+			<element name="DarkBrown">
+				<translation language="English">darkbrown</translation>
+			</element>
+			<element name="DarkGreen">
+				<translation language="English">darkgreen</translation>
+			</element>
+			<element name="DarkPurple">
+				<translation language="English">darkpurple</translation>
+			</element>
+			<element name="Gray">
+				<translation language="English">gray</translation>
+			</element>
+			<element name="Green">
+				<translation language="English">green</translation>
+			</element>
+			<element name="Magenta">
+				<translation language="English">magenta</translation>
+			</element>
+			<element name="Maroon">
+				<translation language="English">maroon</translation>
+			</element>
+			<element name="NavyBlue">
+				<translation language="English">navyblue</translation>
+			</element>
+			<element name="Orange">
+				<translation language="English">orange</translation>
+			</element>
+			<element name="Pink">
+				<translation language="English">pink</translation>
+			</element>
+			<element name="Red">
+				<translation language="English">red</translation>
+			</element>
+			<element name="SlateBlue">
+				<translation language="English">slateblue</translation>
+			</element>
+			<element name="SteelBlue">
+				<translation language="English">steelblue</translation>
+			</element>
+			<element name="Tan">
+				<translation language="English">tan</translation>
+			</element>
+			<element name="White">
+				<translation language="English">white</translation>
+			</element>
+			<element name="Yellow">
+				<translation language="English">yellow</translation>
+			</element>
+		</set>
 		<set name="FolderNames">
 			<element name="AgeJournals">
 				<translation language="English">Folder of Age Journals</translation>

--- a/compiled/dat/GlobalEnglish.loc
+++ b/compiled/dat/GlobalEnglish.loc
@@ -95,10 +95,10 @@
 				<translation language="English">red</translation>
 			</element>
 			<element name="SlateBlue">
-				<translation language="English">slateblue</translation>
+				<translation language="English">skyblue</translation>
 			</element>
 			<element name="SteelBlue">
-				<translation language="English">steelblue</translation>
+				<translation language="English">teal</translation>
 			</element>
 			<element name="Tan">
 				<translation language="English">tan</translation>

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -48,6 +48,68 @@
 				<translation language="French">Allée Tokotah</translation>
 			</element>
 		</set>
+		<set name="Colors">
+			<element name="Black">
+				<translation language="French">noir</translation>
+			</element>
+			<element name="Blue">
+				<translation language="French">bleu</translation>
+			</element>
+			<element name="Brown">
+				<translation language="French">marron</translation>
+			</element>
+			<element name="Cyan">
+				<translation language="French">cyan</translation>
+			</element>
+			<element name="DarkBrown">
+				<translation language="French">brunfoncé</translation>
+			</element>
+			<element name="DarkGreen">
+				<translation language="French">vertforêt</translation>
+			</element>
+			<element name="DarkPurple">
+				<translation language="French">violet</translation>
+			</element>
+			<element name="Gray">
+				<translation language="French">gris</translation>
+			</element>
+			<element name="Green">
+				<translation language="French">vert</translation>
+			</element>
+			<element name="Magenta">
+				<translation language="French">magenta</translation>
+			</element>
+			<element name="Maroon">
+				<translation language="French">pourpre</translation>
+			</element>
+			<element name="NavyBlue">
+				<translation language="French">bleumarin</translation>
+			</element>
+			<element name="Orange">
+				<translation language="French">orange</translation>
+			</element>
+			<element name="Pink">
+				<translation language="French">rose</translation>
+			</element>
+			<element name="Red">
+				<translation language="French">rouge</translation>
+			</element>
+			<element name="SlateBlue">
+				<translation language="French">bleuciel</translation>
+			</element>
+			<element name="SteelBlue">
+				<translation language="French">turquoise</translation>
+			</element>
+			<element name="Tan">
+				<translation language="French">beige</translation>
+			</element>
+			<element name="White">
+				<translation language="French">blanc</translation>
+			</element>
+			<element name="Yellow">
+				<translation language="French">jaune</translation>
+			</element>
+		</set>
 		<set name="FolderNames">
 			<element name="AgeJournals">
 				<translation language="French">Dossiers des journaux d'Âges</translation>

--- a/compiled/dat/GlobalGerman.loc
+++ b/compiled/dat/GlobalGerman.loc
@@ -48,6 +48,68 @@
 				<translation language="German">Tokotah-Straße</translation>
 			</element>
 		</set>
+		<set name="Colors">
+			<element name="Black">
+				<translation language="German">schwarz</translation>
+			</element>
+			<element name="Blue">
+				<translation language="German">blau</translation>
+			</element>
+			<element name="Brown">
+				<translation language="German">braun</translation>
+			</element>
+			<element name="Cyan">
+				<translation language="German">zyan</translation>
+			</element>
+			<element name="DarkBrown">
+				<translation language="German">dunkelbraun</translation>
+			</element>
+			<element name="DarkGreen">
+				<translation language="German">dunkelgrün</translation>
+			</element>
+			<element name="DarkPurple">
+				<translation language="German">lila</translation>
+			</element>
+			<element name="Gray">
+				<translation language="German">grau</translation>
+			</element>
+			<element name="Green">
+				<translation language="German">grün</translation>
+			</element>
+			<element name="Magenta">
+				<translation language="German">magenta</translation>
+			</element>
+			<element name="Maroon">
+				<translation language="German">purpurrot</translation>
+			</element>
+			<element name="NavyBlue">
+				<translation language="German">dunkelblau</translation>
+			</element>
+			<element name="Orange">
+				<translation language="German">orange</translation>
+			</element>
+			<element name="Pink">
+				<translation language="German">rosa</translation>
+			</element>
+			<element name="Red">
+				<translation language="German">rot</translation>
+			</element>
+			<element name="SlateBlue">
+				<translation language="German">himmelsblau</translation>
+			</element>
+			<element name="SteelBlue">
+				<translation language="German">türkis</translation>
+			</element>
+			<element name="Tan">
+				<translation language="German">ocker</translation>
+			</element>
+			<element name="White">
+				<translation language="German">weiß</translation>
+			</element>
+			<element name="Yellow">
+				<translation language="German">gelb</translation>
+			</element>
+		</set>
 		<set name="FolderNames">
 			<element name="AgeJournals">
 				<translation language="German">Ordner der Welten-Journale</translation>

--- a/compiled/dat/GlobalGerman.loc
+++ b/compiled/dat/GlobalGerman.loc
@@ -95,7 +95,7 @@
 				<translation language="German">rot</translation>
 			</element>
 			<element name="SlateBlue">
-				<translation language="German">himmelsblau</translation>
+				<translation language="German">himmelblau</translation>
 			</element>
 			<element name="SteelBlue">
 				<translation language="German">türkis</translation>

--- a/compiled/dat/GlobalItalian.loc
+++ b/compiled/dat/GlobalItalian.loc
@@ -1,6 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
 <localizations>
 	<age name="Global">
+		<set name="Colors">
+			<element name="Black">
+				<translation language="Italian">nero</translation>
+			</element>
+			<element name="Blue">
+				<translation language="Italian">blu</translation>
+			</element>
+			<element name="Brown">
+				<translation language="Italian">marrone</translation>
+			</element>
+			<element name="Cyan">
+				<translation language="Italian">ciano</translation>
+			</element>
+			<element name="DarkBrown">
+				<translation language="Italian">marronescuro</translation>
+			</element>
+			<element name="DarkGreen">
+				<translation language="Italian">verdescuro</translation>
+			</element>
+			<element name="DarkPurple">
+				<translation language="Italian">violascuro</translation>
+			</element>
+			<element name="Gray">
+				<translation language="Italian">grigio</translation>
+			</element>
+			<element name="Green">
+				<translation language="Italian">verde</translation>
+			</element>
+			<element name="Magenta">
+				<translation language="Italian">magenta</translation>
+			</element>
+			<element name="Maroon">
+				<translation language="Italian">bordeaux</translation>
+			</element>
+			<element name="NavyBlue">
+				<translation language="Italian">blumarino</translation>
+			</element>
+			<element name="Orange">
+				<translation language="Italian">arancione</translation>
+			</element>
+			<element name="Pink">
+				<translation language="Italian">rosa</translation>
+			</element>
+			<element name="Red">
+				<translation language="Italian">rosso</translation>
+			</element>
+			<element name="SlateBlue">
+				<translation language="Italian">bluardesia</translation>
+			</element>
+			<element name="SteelBlue">
+				<translation language="Italian">bluacciaio</translation>
+			</element>
+			<element name="Tan">
+				<translation language="Italian">beige</translation>
+			</element>
+			<element name="White">
+				<translation language="Italian">bianco</translation>
+			</element>
+			<element name="Yellow">
+				<translation language="Italian">giallo</translation>
+			</element>
+		</set>
 		<set name="FolderNames">
 			<element name="AgeJournals">
 				<translation language="Italian">Cartella dei Diari delle Età</translation>

--- a/compiled/dat/GlobalItalian.loc
+++ b/compiled/dat/GlobalItalian.loc
@@ -33,7 +33,7 @@
 				<translation language="Italian">magenta</translation>
 			</element>
 			<element name="Maroon">
-				<translation language="Italian">bordeaux</translation>
+				<translation language="Italian">granata</translation>
 			</element>
 			<element name="NavyBlue">
 				<translation language="Italian">blumarino</translation>

--- a/compiled/dat/GlobalSpanish.loc
+++ b/compiled/dat/GlobalSpanish.loc
@@ -11,13 +11,18 @@
 			<element name="Brown">
 				<translation language="Spanish">café</translation>
 			</element>
-			<element name="Cyan">cian</element>
+			<element name="Cyan">
+				<translation language="Spanish">cian</translation>
+			</element>
 			<element name="DarkBrown">
+				<translation language="Spanish">caféoscuro</translation>
 			</element>
 			<element name="DarkGreen">
 				<translation language="Spanish">verdeoscuro</translation>
 			</element>
-			<element name="DarkPurple">morado</element>
+			<element name="DarkPurple">
+				<translation language="Spanish">morado</translation>
+			</element>
 			<element name="Gray">
 				<translation language="Spanish">gris</translation>
 			</element>
@@ -27,8 +32,12 @@
 			<element name="Magenta">
 				<translation language="Spanish">magenta</translation>
 			</element>
-			<element name="Maroon">granate</element>
-			<element name="NavyBlue">azulmarino</element>
+			<element name="Maroon">
+				<translation language="Spanish">granate</translation>
+			</element>
+			<element name="NavyBlue">
+				<translation language="Spanish">azulmarino</translation>
+			</element>
 			<element name="Orange">
 				<translation language="Spanish">anaranjado</translation>
 			</element>
@@ -39,9 +48,14 @@
 				<translation language="Spanish">rojo</translation>
 			</element>
 			<element name="SlateBlue">
+				<translation language="Spanish">azulcielo</translation>
 			</element>
-			<element name="SteelBlue">verdeazulado</element>
-			<element name="Tan">caféclaro</element>
+			<element name="SteelBlue">
+				<translation language="Spanish">verdeazulado</translation>
+			</element>
+			<element name="Tan">
+				<translation language="Spanish">caféclaro</translation>
+			</element>
 			<element name="White">
 				<translation language="Spanish">blanco</translation>
 			</element>

--- a/compiled/dat/GlobalSpanish.loc
+++ b/compiled/dat/GlobalSpanish.loc
@@ -1,6 +1,60 @@
 <?xml version="1.0" encoding="utf-8"?>
 <localizations>
 	<age name="Global">
+		<set name="Colors">
+			<element name="Black">
+				<translation language="Spanish">negro</translation>
+			</element>
+			<element name="Blue">
+				<translation language="Spanish">azul</translation>
+			</element>
+			<element name="Brown">
+				<translation language="Spanish">marrón</translation>
+			</element>
+			<element name="Cyan">
+			</element>
+			<element name="DarkBrown">
+			</element>
+			<element name="DarkGreen">
+				<translation language="Spanish">verdeoscuro</translation>
+			</element>
+			<element name="DarkPurple">
+			</element>
+			<element name="Gray">
+				<translation language="Spanish">gris</translation>
+			</element>
+			<element name="Green">
+				<translation language="Spanish">verde</translation>
+			</element>
+			<element name="Magenta">
+				<translation language="Spanish">magenta</translation>
+			</element>
+			<element name="Maroon">
+			</element>
+			<element name="NavyBlue">
+			</element>
+			<element name="Orange">
+				<translation language="Spanish">naranja</translation>
+			</element>
+			<element name="Pink">
+				<translation language="Spanish">rosa</translation>
+			</element>
+			<element name="Red">
+				<translation language="Spanish">rojo</translation>
+			</element>
+			<element name="SlateBlue">
+			</element>
+			<element name="SteelBlue">
+			</element>
+			<element name="Tan">
+			</element>
+			<element name="White">
+				<translation language="Spanish">blanco</translation>
+			</element>
+			<element name="Yellow">
+				<translation language="Spanish">amarillo</translation>
+			</element>
+		</set>
 		<set name="FolderNames">
 			<element name="AgeJournals">
 				<translation language="Spanish">Carpeta de documentación de las Eras</translation>
@@ -58,60 +112,6 @@
 			</element>
 			<element name="UserDefined">
 				<translation language="Spanish">Usuario definido</translation>
-			</element>
-		</set>
-		<set name="Colors">
-			<element name="Black">
-				<translation language="Spanish">negro</translation>
-			</element>
-			<element name="Blue">
-				<translation language="Spanish">azul</translation>
-			</element>
-			<element name="Brown">
-				<translation language="Spanish">marrón</translation>
-			</element>
-			<element name="Cyan">
-			</element>
-			<element name="DarkBrown">
-			</element>
-			<element name="DarkGreen">
-				<translation language="Spanish">verdeoscuro</translation>
-			</element>
-			<element name="DarkPurple">
-			</element>
-			<element name="Gray">
-				<translation language="Spanish">gris</translation>
-			</element>
-			<element name="Green">
-				<translation language="Spanish">verde</translation>
-			</element>
-			<element name="Magenta">
-				<translation language="Spanish">magenta</translation>
-			</element>
-			<element name="Maroon">
-			</element>
-			<element name="NavyBlue">
-			</element>
-			<element name="Orange">
-				<translation language="Spanish">naranja</translation>
-			</element>
-			<element name="Pink">
-				<translation language="Spanish">rosa</translation>
-			</element>
-			<element name="Red">
-				<translation language="Spanish">rojo</translation>
-			</element>
-			<element name="SlateBlue">
-			</element>
-			<element name="SteelBlue">
-			</element>
-			<element name="Tan">
-			</element>
-			<element name="White">
-				<translation language="Spanish">blanco</translation>
-			</element>
-			<element name="Yellow">
-				<translation language="Spanish">amarillo</translation>
 			</element>
 		</set>
 		<set name="Formats">

--- a/compiled/dat/GlobalSpanish.loc
+++ b/compiled/dat/GlobalSpanish.loc
@@ -60,6 +60,60 @@
 				<translation language="Spanish">Usuario definido</translation>
 			</element>
 		</set>
+		<set name="Colors">
+			<element name="Black">
+				<translation language="Spanish">negro</translation>
+			</element>
+			<element name="Blue">
+				<translation language="Spanish">azul</translation>
+			</element>
+			<element name="Brown">
+				<translation language="Spanish">marrón</translation>
+			</element>
+			<element name="Cyan">
+			</element>
+			<element name="DarkBrown">
+			</element>
+			<element name="DarkGreen">
+				<translation language="Spanish">verdeoscuro</translation>
+			</element>
+			<element name="DarkPurple">
+			</element>
+			<element name="Gray">
+				<translation language="Spanish">gris</translation>
+			</element>
+			<element name="Green">
+				<translation language="Spanish">verde</translation>
+			</element>
+			<element name="Magenta">
+				<translation language="Spanish">magenta</translation>
+			</element>
+			<element name="Maroon">
+			</element>
+			<element name="NavyBlue">
+			</element>
+			<element name="Orange">
+				<translation language="Spanish">naranja</translation>
+			</element>
+			<element name="Pink">
+				<translation language="Spanish">rosa</translation>
+			</element>
+			<element name="Red">
+				<translation language="Spanish">rojo</translation>
+			</element>
+			<element name="SlateBlue">
+			</element>
+			<element name="SteelBlue">
+			</element>
+			<element name="Tan">
+			</element>
+			<element name="White">
+				<translation language="Spanish">blanco</translation>
+			</element>
+			<element name="Yellow">
+				<translation language="Spanish">amarillo</translation>
+			</element>
+		</set>
 		<set name="Formats">
 			<element name="Date">
 				<translation language="Spanish">\%d/\%m/\%y</translation>

--- a/compiled/dat/GlobalSpanish.loc
+++ b/compiled/dat/GlobalSpanish.loc
@@ -9,17 +9,15 @@
 				<translation language="Spanish">azul</translation>
 			</element>
 			<element name="Brown">
-				<translation language="Spanish">marrón</translation>
+				<translation language="Spanish">café</translation>
 			</element>
-			<element name="Cyan">
-			</element>
+			<element name="Cyan">cian</element>
 			<element name="DarkBrown">
 			</element>
 			<element name="DarkGreen">
 				<translation language="Spanish">verdeoscuro</translation>
 			</element>
-			<element name="DarkPurple">
-			</element>
+			<element name="DarkPurple">morado</element>
 			<element name="Gray">
 				<translation language="Spanish">gris</translation>
 			</element>
@@ -29,12 +27,10 @@
 			<element name="Magenta">
 				<translation language="Spanish">magenta</translation>
 			</element>
-			<element name="Maroon">
-			</element>
-			<element name="NavyBlue">
-			</element>
+			<element name="Maroon">granate</element>
+			<element name="NavyBlue">azulmarino</element>
 			<element name="Orange">
-				<translation language="Spanish">naranja</translation>
+				<translation language="Spanish">anaranjado</translation>
 			</element>
 			<element name="Pink">
 				<translation language="Spanish">rosa</translation>
@@ -44,10 +40,8 @@
 			</element>
 			<element name="SlateBlue">
 			</element>
-			<element name="SteelBlue">
-			</element>
-			<element name="Tan">
-			</element>
+			<element name="SteelBlue">verdeazulado</element>
+			<element name="Tan">caféclaro</element>
 			<element name="White">
 				<translation language="Spanish">blanco</translation>
 			</element>

--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -140,7 +140,7 @@
 				<translation language="English">TO:</translation>
 			</element>
 			<element name="TextColorSetDefault">
-				<translation language="English">Text color reset to default color(s).</translation>
+				<translation language="English">Text reset to default color(s).</translation>
 			</element>
 			<element name="TextColorSetValue">
 				<translation language="English">Text color now set to %1s.</translation>

--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -139,6 +139,12 @@
 			<element name="TOPrompt">
 				<translation language="English">TO:</translation>
 			</element>
+			<element name="TextColorSetDefault">
+				<translation language="English">Text color now set to default color(s).</translation>
+			</element>
+			<element name="TextColorSetValue">
+				<translation language="English">Text color now set to %1s.</translation>
+			</element>
 			<element name="WentOffline">
 				<translation language="English">(%1s is offline and cannot be reached for chatting.)</translation>
 			</element>
@@ -203,6 +209,12 @@
 			</element>
 			<element name="ChatReply">
 				<translation language="English">/reply</translation>
+			</element>
+			<element name="ChatSetTextColor">
+				<translation language="English">/textcolor</translation>
+			</element>
+			<element name="ChatSetTextColorDefaultArg">
+				<translation language="English">default</translation>
 			</element>
 			<element name="ChatStartLog">
 				<translation language="English">/startlog</translation>
@@ -716,6 +728,9 @@
 			<element name="LoggedInElsewhere">
 				<translation language="English">You have been disconnected because someone else is currently using your account.
 #02</translation>
+			</element>
+			<element name="MalformedChatSetTextColorCmd">
+				<translation language="English">You must specify a valid color name, a valid 3- or 6-character hexadecimal color, a triplet of decimal numbers between 0 and 1, or "default".</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 				<translation language="English">You must specify a folder to dump logs to</translation>

--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -730,7 +730,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="English">You must specify one of the following: a valid color name, a valid 3- or 6-character hexadecimal color, a set of three decimal numbers between 0 and 1, a set of three integers between 0 and 255, or "default".</translation>
+				<translation language="English">You must specify one of the following: a valid color name, a valid 3- or 6-character hexadecimal color, a set of three decimal numbers between 0 and 1, a set of three integers between 0 and 255, or "default". Valid color names are: black, blue, brown, cyan, darkbrown, darkgreen, purple, gray, green, magenta, maroon, navyblue, orange, pink, red, skyblue, teal, tan, white, and yellow.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 				<translation language="English">You must specify a folder to dump logs to</translation>

--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -140,7 +140,7 @@
 				<translation language="English">TO:</translation>
 			</element>
 			<element name="TextColorSetDefault">
-				<translation language="English">Text color now set to default color(s).</translation>
+				<translation language="English">Text color reset to default color(s).</translation>
 			</element>
 			<element name="TextColorSetValue">
 				<translation language="English">Text color now set to %1s.</translation>
@@ -730,7 +730,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="English">You must specify a valid color name, a valid 3- or 6-character hexadecimal color, a triplet of decimal numbers between 0 and 1, or "default".</translation>
+				<translation language="English">You must specify one of the following: a valid color name, a valid 3- or 6-character hexadecimal color, a set of three decimal numbers between 0 and 1, a set of three integers between 0 and 255, or "default".</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 				<translation language="English">You must specify a folder to dump logs to</translation>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -640,7 +640,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="French">Vous devez spécifier l'un des éléments suivants : un nom de couleur valide, un code couleur HEX valide de 3 ou 6 caractères, un ensemble de trois nombres décimaux compris entre 0 et 1, un ensemble de trois nombres entiers compris entre 0 et 255, ou "défaut". Les noms de couleurs valides sont : noir, bleu, marron, cyan, brunfoncé, vertforêt, violet, gris, vert, magenta, pourpre, bleumarin, orange, rose, rouge, bleuciel, turquoise, beige, blanc, et jaune.</translation>
+				<translation language="French">Vous devez spécifier l'un des éléments suivants : un nom de couleur valide, un code couleur HEX valide de 3 ou 6 caractères, un ensemble de trois nombres décimaux compris entre 0 et 1, un ensemble de trois nombres entiers compris entre 0 et 255, ou "défaut". Les noms des couleurs valides sont : noir, bleu, marron, cyan, brunfoncé, vertforêt, violet, gris, vert, magenta, pourpre, bleumarin, orange, rose, rouge, bleuciel, turquoise, beige, blanc, et jaune.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -139,8 +139,10 @@
 				<translation language="French">À :</translation>
 			</element>
 			<element name="TextColorSetDefault">
+				<translation language="French">Couleur du texte réinitialisée à la ou aux couleurs défaut.</translation>
 			</element>
 			<element name="TextColorSetValue">
+				<translation language="French">Couleur du texte est définie à %1s.</translation>
 			</element>
 			<element name="WentOffline">
 				<translation language="French">(%1s est hors ligne. Conversation impossible.)</translation>
@@ -198,8 +200,10 @@
 				<translation language="French">/répondre</translation>
 			</element>
 			<element name="ChatSetTextColor">
+				<translation language="French">/couleurtexte</translation>
 			</element>
 			<element name="ChatSetTextColorDefaultArg">
+				<translation language="French">défaut</translation>
 			</element>
 			<element name="ChatStartLog">
 				<translation language="French">/démarrerlog</translation>
@@ -636,6 +640,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
+				<translation language="French">Vous devez spécifier l'un des éléments suivants : un nom de couleur valide, un code couleur HEX valide de 3 ou 6 caractères, un ensemble de trois nombres décimaux compris entre 0 et 1, un ensemble de trois nombres entiers compris entre 0 et 255, ou "défaut".</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -139,7 +139,7 @@
 				<translation language="French">À :</translation>
 			</element>
 			<element name="TextColorSetDefault">
-				<translation language="French">Couleur du texte réinitialisée à la ou aux couleurs défaut.</translation>
+				<translation language="French">Texte réinitialisée à la ou aux couleurs défaut.</translation>
 			</element>
 			<element name="TextColorSetValue">
 				<translation language="French">Couleur du texte est définie à %1s.</translation>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -640,7 +640,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="French">Vous devez spécifier l'un des éléments suivants : un nom de couleur valide, un code couleur HEX valide de 3 ou 6 caractères, un ensemble de trois nombres décimaux compris entre 0 et 1, un ensemble de trois nombres entiers compris entre 0 et 255, ou "défaut".</translation>
+				<translation language="French">Vous devez spécifier l'un des éléments suivants : un nom de couleur valide, un code couleur HEX valide de 3 ou 6 caractères, un ensemble de trois nombres décimaux compris entre 0 et 1, un ensemble de trois nombres entiers compris entre 0 et 255, ou "défaut". Les noms de couleurs valides sont : noir, bleu, marron, cyan, brunfoncé, vertforêt, violet, gris, vert, magenta, pourpre, bleumarin, orange, rose, rouge, bleuciel, turquoise, beige, blanc, et jaune.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -138,6 +138,10 @@
 			<element name="TOPrompt">
 				<translation language="French">À :</translation>
 			</element>
+			<element name="TextColorSetDefault">
+			</element>
+			<element name="TextColorSetValue">
+			</element>
 			<element name="WentOffline">
 				<translation language="French">(%1s est hors ligne. Conversation impossible.)</translation>
 			</element>
@@ -192,6 +196,10 @@
 			</element>
 			<element name="ChatReply">
 				<translation language="French">/répondre</translation>
+			</element>
+			<element name="ChatSetTextColor">
+			</element>
+			<element name="ChatSetTextColorDefaultArg">
 			</element>
 			<element name="ChatStartLog">
 				<translation language="French">/démarrerlog</translation>
@@ -626,6 +634,8 @@
 			<element name="LoggedInElsewhere">
 				<translation language="French">Vous avez été déconnecté(e) car quelqu'un d'autre utilise déjà votre compte.
 #02</translation>
+			</element>
+			<element name="MalformedChatSetTextColorCmd">
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -642,7 +642,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="German">Die Textfarbe muss in einem der folgenden Formate angegeben werden: ein gültiger Farbname, eine gültige Hexadezimalfarbe aus 3 oder 6 Zeichen, drei Dezimalzahlen zwischen 0 und 1, drei Ganzzahlen zwischen 0 und 255, oder "Standard".</translation>
+				<translation language="German">Die Textfarbe muss in einem der folgenden Formate angegeben werden: ein gültiger Farbname, eine gültige Hexadezimalfarbe aus 3 oder 6 Zeichen, drei Dezimalzahlen zwischen 0 und 1, drei Ganzzahlen zwischen 0 und 255, oder "Standard". Die gültigen Farbnamen sind: schwarz, blau, braun, zyan, dunkelbraun, dunkelgrün, lila, grau, grün, magenta, purpurrot, orange, rosa, rot, himmelsblau, türkis, ocker, weiß, und gelb.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -138,6 +138,10 @@
 			<element name="TOPrompt">
 				<translation language="German">AN:</translation>
 			</element>
+			<element name="TextColorSetDefault">
+			</element>
+			<element name="TextColorSetValue">
+			</element>
 			<element name="WentOffline">
 				<translation language="German">(%1s ist offline und nicht für einen Chat verfügbar.)</translation>
 			</element>
@@ -192,6 +196,10 @@
 			</element>
 			<element name="ChatReply">
 				<translation language="German">/antworten</translation>
+			</element>
+			<element name="ChatSetTextColor">
+			</element>
+			<element name="ChatSetTextColorDefaultArg">
 			</element>
 			<element name="ChatStartLog">
 				<translation language="German">/protokollan</translation>
@@ -628,6 +636,8 @@
 			<element name="LoggedInElsewhere">
 				<translation language="German">Ihre Verbindung wurde getrennt, da Ihr Konto bereits benutzt wird.
 #02</translation>
+			</element>
+			<element name="MalformedChatSetTextColorCmd">
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -642,7 +642,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="German">Die Textfarbe muss in einem der folgenden Formate angegeben werden: ein gültiger Farbname, eine gültige Hexadezimalfarbe aus 3 oder 6 Zeichen, drei Dezimalzahlen zwischen 0 und 1, drei Ganzzahlen zwischen 0 und 255, oder "Standard". Die gültigen Farbnamen sind: schwarz, blau, braun, zyan, dunkelbraun, dunkelgrün, lila, grau, grün, magenta, purpurrot, orange, rosa, rot, himmelsblau, türkis, ocker, weiß, und gelb.</translation>
+				<translation language="German">Die Textfarbe muss in einem der folgenden Formate angegeben werden: ein gültiger Farbname, eine gültige Hexadezimalfarbe aus 3 oder 6 Zeichen, drei Dezimalzahlen zwischen 0 und 1, drei Ganzzahlen zwischen 0 und 255, oder "Standard". Die gültigen Farbnamen sind: schwarz, blau, braun, zyan, dunkelbraun, dunkelgrün, lila, grau, grün, magenta, purpurrot, orange, rosa, rot, himmelblau, türkis, ocker, weiß und gelb.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -198,6 +198,7 @@
 				<translation language="German">/antworten</translation>
 			</element>
 			<element name="ChatSetTextColor">
+				<translation language="German">/textfarbe</translation>
 			</element>
 			<element name="ChatSetTextColorDefaultArg">
 			</element>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -139,8 +139,10 @@
 				<translation language="German">AN:</translation>
 			</element>
 			<element name="TextColorSetDefault">
+				<translation language="German">Textfarbe(n) auf Standard zurückgesetzt.</translation>
 			</element>
 			<element name="TextColorSetValue">
+				<translation language="German">Textfarbe auf %1s geändert.</translation>
 			</element>
 			<element name="WentOffline">
 				<translation language="German">(%1s ist offline und nicht für einen Chat verfügbar.)</translation>
@@ -201,6 +203,7 @@
 				<translation language="German">/textfarbe</translation>
 			</element>
 			<element name="ChatSetTextColorDefaultArg">
+				<translation language="German">standard</translation>
 			</element>
 			<element name="ChatStartLog">
 				<translation language="German">/protokollan</translation>
@@ -639,6 +642,7 @@
 #02</translation>
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
+				<translation language="German">Die Textfarbe muss in einem der folgenden Formate angegeben werden: ein gültiger Farbname, eine gültige Hexadezimalfarbe aus 3 oder 6 Zeichen, drei Dezimalzahlen zwischen 0 und 1, drei Ganzzahlen zwischen 0 und 255, oder "Standard".</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -132,6 +132,10 @@
 			<element name="TOPrompt">
 				<translation language="Italian">A:</translation>
 			</element>
+			<element name="TextColorSetDefault">
+			</element>
+			<element name="TextColorSetValue">
+			</element>
 			<element name="WentOffline">
 				<translation language="Italian">(%1s è offline e non può essere raggiunto in chat.)</translation>
 			</element>
@@ -186,6 +190,10 @@
 			</element>
 			<element name="ChatReply">
 				<translation language="Italian">/reply</translation>
+			</element>
+			<element name="ChatSetTextColor">
+			</element>
+			<element name="ChatSetTextColorDefaultArg">
 			</element>
 			<element name="ChatStartLog">
 				<translation language="Italian">/startlog</translation>
@@ -587,6 +595,8 @@
 			<element name="LinkingRestored">
 			</element>
 			<element name="LoggedInElsewhere">
+			</element>
+			<element name="MalformedChatSetTextColorCmd">
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -133,8 +133,10 @@
 				<translation language="Italian">A:</translation>
 			</element>
 			<element name="TextColorSetDefault">
+				<translation language="Italian">Testo reimpostato al/ai colore/i predefinito/i.</translation>
 			</element>
 			<element name="TextColorSetValue">
+				<translation language="Italian">Colore del testo impostato a %1s.</translation>
 			</element>
 			<element name="WentOffline">
 				<translation language="Italian">(%1s è offline e non può essere raggiunto in chat.)</translation>
@@ -192,8 +194,10 @@
 				<translation language="Italian">/reply</translation>
 			</element>
 			<element name="ChatSetTextColor">
+				<translation language="Italian">/coloretesto</translation>
 			</element>
 			<element name="ChatSetTextColorDefaultArg">
+				<translation language="Italian">predefinito</translation>
 			</element>
 			<element name="ChatStartLog">
 				<translation language="Italian">/startlog</translation>
@@ -597,6 +601,7 @@
 			<element name="LoggedInElsewhere">
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
+				<translation language="Italian">Devi specificare uno dei seguenti: un nome valido di colore, una sequenza esadecimale valida di 3 o 6 caratteri, un gruppo di tre numeri decimali tra 0 e 1, un gruppo di tre interi tra 0 e 255, o "predefinito".</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -601,7 +601,7 @@
 			<element name="LoggedInElsewhere">
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="Italian">Devi specificare uno dei seguenti: un nome valido di colore, una sequenza esadecimale valida di 3 o 6 caratteri, un gruppo di tre numeri decimali tra 0 e 1, un gruppo di tre interi tra 0 e 255, o "predefinito".</translation>
+				<translation language="Italian">Devi specificare uno dei seguenti: un nome valido di colore, una sequenza esadecimale valida di 3 o 6 caratteri, un gruppo di tre numeri decimali tra 0 e 1, un gruppo di tre interi tra 0 e 255, o "predefinito". Nomi di colore validi sono: nero, blu, marrone, ciano, marronescuro, verdescuro, violascuro, grigio, verde, magenta, bordeaux, blumarino, arancione, rosa, rosso, bluardesia, bluacciaio, beige, bianco, e giallo</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -601,7 +601,7 @@
 			<element name="LoggedInElsewhere">
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
-				<translation language="Italian">Devi specificare uno dei seguenti: un nome valido di colore, una sequenza esadecimale valida di 3 o 6 caratteri, un gruppo di tre numeri decimali tra 0 e 1, un gruppo di tre interi tra 0 e 255, o "predefinito". Nomi di colore validi sono: nero, blu, marrone, ciano, marronescuro, verdescuro, violascuro, grigio, verde, magenta, bordeaux, blumarino, arancione, rosa, rosso, bluardesia, bluacciaio, beige, bianco, e giallo</translation>
+				<translation language="Italian">Devi specificare uno dei seguenti: un nome valido di colore, una sequenza esadecimale valida di 3 o 6 caratteri, un gruppo di tre numeri decimali tra 0 e 1, un gruppo di tre interi tra 0 e 255, o "predefinito". Nomi di colore validi sono: nero, blu, marrone, ciano, marronescuro, verdescuro, violascuro, grigio, verde, magenta, granata, blumarino, arancione, rosa, rosso, bluardesia, bluacciaio, beige, bianco, e giallo.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -132,6 +132,10 @@
 			<element name="TOPrompt">
 				<translation language="Spanish">A:</translation>
 			</element>
+			<element name="TextColorSetDefault">
+			</element>
+			<element name="TextColorSetValue">
+			</element>
 			<element name="WentOffline">
 				<translation language="Spanish">(No puedo encontrar a "%1s" en ninguna de las listas de jugadores.)</translation>
 			</element>
@@ -186,6 +190,10 @@
 			</element>
 			<element name="ChatReply">
 				<translation language="Spanish">/responder</translation>
+			</element>
+			<element name="ChatSetTextColor">
+			</element>
+			<element name="ChatSetTextColorDefaultArg">
 			</element>
 			<element name="ChatStartLog">
 				<translation language="Spanish">/iniciar registro</translation>
@@ -586,6 +594,8 @@
 			<element name="LinkingRestored">
 			</element>
 			<element name="LoggedInElsewhere">
+			</element>
+			<element name="MalformedChatSetTextColorCmd">
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -192,8 +192,10 @@
 				<translation language="Spanish">/responder</translation>
 			</element>
 			<element name="ChatSetTextColor">
+				<translation language="Spanish">/colortexto</translation>
 			</element>
 			<element name="ChatSetTextColorDefaultArg">
+				<translation language="Spanish">predeterminado</translation>
 			</element>
 			<element name="ChatStartLog">
 				<translation language="Spanish">/iniciar registro</translation>
@@ -596,6 +598,7 @@
 			<element name="LoggedInElsewhere">
 			</element>
 			<element name="MalformedChatSetTextColorCmd">
+				<translation language="Spanish">Los nombres de colores válidos son: negro, azul, café, cian, caféoscuro, verdeoscuro, morado, gris, verde, magenta, granate, azulmarino, anaranjado, rosa, rojo, azulcielo, verdeazulado, caféclaro, blanco, y amarillo.</translation>
 			</element>
 			<element name="MalformedLogDumpCmd">
 			</element>


### PR DESCRIPTION
~~No translations available yet for command, default arg value, status messages, or error/usage message. I need to reach out to some translators in the OU discord to get at least French and German, probably. I'm not 100% happy with the wording in the error/usage message in English, though, so I'd like to get some suggestions from y'all and smooth that out first.~~

Reworked error/usage message to a place where I am reasonably happy with it. French and German translations kindly provided by skyisblu and @dgelessus, respectively. Some Spanish color names based on old college Spanish knowledge and Google but I don't expect we'll get a native translator for the rest of the functionality in Spanish ~~or in Italian~~ any time soon. I was wrong about the Italian functionality; Italian has been kindly provided by aurora and Korovev in the OU discord.

Ready for review and merge whenever if there is no more feedback.