### PR TITLE
Add and fix possessive formatters for foreign languages

### DIFF
--- a/compiled/dat/GlobalEnglish.loc
+++ b/compiled/dat/GlobalEnglish.loc
@@ -114,7 +114,7 @@
 			<element name="DateTime">
 				<translation language="English">\%m/\%d/\%y  \%H:\%M</translation>
 			</element>
-			<element name="Possesive">
+			<element name="Possessive">
 				<translation language="English">%1s's %2s</translation>
 			</element>
 		</set>

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -114,7 +114,7 @@
 			<element name="DateTime">
 				<translation language="French">\%d/\%m/\%y  \%H:\%M</translation>
 			</element>
-			<element name="Possesive">
+			<element name="Possessive">
 				<translation language="French">%2s de %1s</translation>
 			</element>
 		</set>

--- a/compiled/dat/GlobalGerman.loc
+++ b/compiled/dat/GlobalGerman.loc
@@ -114,8 +114,8 @@
 			<element name="DateTime">
 				<translation language="German">\%d/\%m/\%y  \%H:\%M</translation>
 			</element>
-			<element name="Possesive">
-				<translation language="German">%2s de %1s</translation>
+			<element name="Possessive">
+				<translation language="German">%1ss %2s</translation>
 			</element>
 		</set>
 		<set name="Journals">

--- a/compiled/dat/GlobalItalian.loc
+++ b/compiled/dat/GlobalItalian.loc
@@ -67,7 +67,8 @@
 			<element name="DateTime">
 				<translation language="Italian">\%d/\%m/\%y  \%H:\%M</translation>
 			</element>
-			<element name="Possesive">
+			<element name="Possessive">
+				<translation language="Italian">%2s di %1s</translation>
 			</element>
 		</set>
 		<set name="Journals">

--- a/compiled/dat/GlobalSpanish.loc
+++ b/compiled/dat/GlobalSpanish.loc
@@ -67,7 +67,8 @@
 			<element name="DateTime">
 				<translation language="Spanish">\%d/\%m/\%y  \%H:\%M</translation>
 			</element>
-			<element name="Possesive">
+			<element name="Possessive">
+				<translation language="Spanish">%2s de %1s</translation>
 			</element>
 		</set>
 		<set name="Journals">

--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -891,6 +891,9 @@ Signed,
 			<element name="Captures">
 				<translation language="English">%1s captures "%2s". %3s</translation>
 			</element>
+			<element name="DefaultGameTitle">
+				<translation language="English">Marker Game</translation>
+			</element>
 			<element name="DoneEditButton">
 				<translation language="English">Done Editing</translation>
 			</element>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -798,6 +798,9 @@ Signé(e),
 			<element name="Captures">
 				<translation language="French">%1s a capturé « %2s ». %3s</translation>
 			</element>
+			<element name="DefaultGameTitle">
+				<translation language="French">Jeu de Marqueurs</translation>
+			</element>
 			<element name="DoneEditButton">
 				<translation language="French">Modification terminée</translation>
 			</element>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -800,6 +800,9 @@ Gruß,
 			<element name="Captures">
 				<translation language="German">%1s erobert "%2s". %3s</translation>
 			</element>
+			<element name="DefaultGameTitle">
+				<translation language="German">Markerspiel</translation>
+			</element>
 			<element name="DoneEditButton">
 				<translation language="German">Bearbeiten beenden</translation>
 			</element>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -731,6 +731,9 @@ Firmato,
 			<element name="Captures">
 				<translation language="Italian">%1s cattura "%2s". %3s</translation>
 			</element>
+			<element name="DefaultGameTitle">
+				<translation language="Italian">Partita Marker</translation>
+			</element>
 			<element name="DoneEditButton">
 				<translation language="Italian">Modifiche terminate</translation>
 			</element>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -730,6 +730,9 @@ Firmado,
 			<element name="Captures">
 				<translation language="Spanish">%1s capturas "%2s". %3s</translation>
 			</element>
+			<element name="DefaultGameTitle">
+				<translation language="Spanish">Partida Marcador</translation>
+			</element>
 			<element name="DoneEditButton">
 				<translation language="Spanish">Edición realizada</translation>
 			</element>


### PR DESCRIPTION
Fix the misspelled LOC key string, fix German format based on feedback by dgelessus and Prad in the OU discord, and add baseline Italian and Spanish so they don't use the English format (which was definitely wrong).