### PR TITLE
Fix reference to stale DSpan object in Markers.

### DIFF
--- a/compiled/dat/GlobalMarkers_District_Markers.prp
+++ b/compiled/dat/GlobalMarkers_District_Markers.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e0b9b1410898f27138ff0dc572d74248262a1e202ae1a2a1b7709a5454d6478e
-size 34341
+oid sha256:680c3cbe6fbf6ed8843d51f2d884001326508dba62fdaabb6cce0e9b5243c7ce
+size 34339


### PR DESCRIPTION
This fixes a crash, presumably introduced by #32, caused by references to a stale DSpan object. The crash could be observed by creating a marker game an attempting to add a marker to it.