### PR TITLE
Fixes Relto door animations to be centered in doorframe

### DIFF
--- a/compiled/dat/Personal_District_psnlMYSTII.prp
+++ b/compiled/dat/Personal_District_psnlMYSTII.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14b89aa77b4b0685ae4ce4ffbf75422407c929119c4d3cabb4f6b6132e3a31d1
+oid sha256:95436e19f44b37f613b6b66936a035f3b3084cb11dc2551095de0efba24096ec
 size 8591326


### PR DESCRIPTION
Got a request to fix the animation for the doors in Relto so they were properly centered in the grooves of the hut

Video of the new animation
https://youtu.be/Nj4YEjmUvI4