### PR TITLE
Minkata Soccerball issue

### DIFF
--- a/compiled/dat/Minkata_District_minkCameras.prp
+++ b/compiled/dat/Minkata_District_minkCameras.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1e6ae6b53f414b7ab6184b243f62011e713b0dcbd5f6ad422dd08bd0221cd6c3
-size 97551
+oid sha256:6f3327dba90f26c98e5394d683ee0d1d1c360e88e1a8696c6aea63c555f18456
+size 70189


### PR DESCRIPTION
The Minkata Soccer ball with the OU client will be invisible until the ball is moved a bit.
This is a work around for that behavior and moves the ball up to 5 feet from 1 foot.
When the age is initialized it causes the soccer ball to fall and become visible.

This issue does not affect the H'uru client at all.
These changes cause no visible change to the soccer ball on H'uru client.

This PR is strictly to keep the two codebases in sync with each other.