### PR TITLE
KI chat context prefixes

### DIFF
--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -65,10 +65,10 @@
 				<translation language="English">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
-				<translation language="English"> </translation>
+				<translation language="English"></translation>
 			</element>
 			<element name="BroadcastSendTo">
-				<translation language="English"> </translation>
+				<translation language="English"></translation>
 			</element>
 			<element name="BuddiesContextPrefix">
 				<translation language="English">[BUDDIES] </translation>
@@ -135,6 +135,9 @@
 			</element>
 			<element name="MarkerTORedTeam">
 				<translation language="English">TO:RedTeam &gt;</translation>
+			</element>
+			<element name="MentionContextPrefix">
+				<translation language="English">[PING] </translation>
 			</element>
 			<element name="NeighborsContextPrefix">
 				<translation language="English">[NEIGHBORS] </translation>

--- a/compiled/dat/KIEnglish.loc
+++ b/compiled/dat/KIEnglish.loc
@@ -61,11 +61,20 @@
 			<element name="AFK">
 				<translation language="English"> (I'm on the surface, be back in a minute)</translation>
 			</element>
+			<element name="AdminContextPrefix">
+				<translation language="English">[ADMIN] </translation>
+			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="English"> </translation>
 			</element>
 			<element name="BroadcastSendTo">
 				<translation language="English"> </translation>
+			</element>
+			<element name="BuddiesContextPrefix">
+				<translation language="English">[BUDDIES] </translation>
+			</element>
+			<element name="CCRContextPrefix">
+				<translation language="English">[CCR] </translation>
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="English">From %1s to CCR:</translation>
@@ -78,6 +87,9 @@
 			</element>
 			<element name="CannotFindBuddy">
 				<translation language="English">(Can't find "%1s" in any of the player lists.)</translation>
+			</element>
+			<element name="ErrorContextPrefix">
+				<translation language="English">[ERROR] </translation>
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="English">Error:</translation>
@@ -124,17 +136,26 @@
 			<element name="MarkerTORedTeam">
 				<translation language="English">TO:RedTeam &gt;</translation>
 			</element>
+			<element name="NeighborsContextPrefix">
+				<translation language="English">[NEIGHBORS] </translation>
+			</element>
 			<element name="NoOneListening">
 				<translation language="English">(You're standing too far away, perhaps if you shout?)</translation>
 			</element>
 			<element name="NoOneToReply">
 				<translation language="English">(There is no one to reply to.)</translation>
 			</element>
+			<element name="PrivateContextPrefix">
+				<translation language="English">[PRIVATE] </translation>
+			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="English">From </translation>
 			</element>
 			<element name="PrivateSendTo">
 				<translation language="English">To </translation>
+			</element>
+			<element name="SubtitleContextPrefix">
+				<translation language="English">[SUBTITLE] </translation>
 			</element>
 			<element name="TOPrompt">
 				<translation language="English">TO:</translation>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -62,6 +62,7 @@
 				<translation language="French"> (Je suis à la surface. Je serai de retour dans une minute)</translation>
 			</element>
 			<element name="AdminContextPrefix">
+				<translation language="French">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="French"> </translation>
@@ -70,8 +71,10 @@
 				<translation language="French"> </translation>
 			</element>
 			<element name="BuddiesContextPrefix">
+				<translation language="French">[AMIS] </translation>
 			</element>
 			<element name="CCRContextPrefix">
+				<translation language="French">[PAC] </translation>
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="French">De %1s à PAC :</translation>
@@ -85,6 +88,7 @@
 			<element name="CannotFindBuddy">
 			</element>
 			<element name="ErrorContextPrefix">
+				<translation language="French">[ERREUR] </translation>
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="French">Erreur :</translation>
@@ -132,6 +136,7 @@
 				<translation language="French">À : Équipe rouge &gt;</translation>
 			</element>
 			<element name="NeighborsContextPrefix">
+				<translation language="French">[VOISINS] </translation>
 			</element>
 			<element name="NoOneListening">
 				<translation language="French">(Vous êtes trop loin. Vous devriez peut-être crier ?)</translation>
@@ -140,6 +145,7 @@
 				<translation language="French">(Il n'y a personne à qui répondre.)</translation>
 			</element>
 			<element name="PrivateContextPrefix">
+				<translation language="French">[PRIVÉ] </translation>
 			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="French">De </translation>
@@ -148,6 +154,7 @@
 				<translation language="French">À </translation>
 			</element>
 			<element name="SubtitleContextPrefix">
+				<translation language="French">[SOUS-TITRE] </translation>
 			</element>
 			<element name="TOPrompt">
 				<translation language="French">À :</translation>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -61,11 +61,17 @@
 			<element name="AFK">
 				<translation language="French"> (Je suis à la surface. Je serai de retour dans une minute)</translation>
 			</element>
+			<element name="AdminContextPrefix">
+			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="French"> </translation>
 			</element>
 			<element name="BroadcastSendTo">
 				<translation language="French"> </translation>
+			</element>
+			<element name="BuddiesContextPrefix">
+			</element>
+			<element name="CCRContextPrefix">
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="French">De %1s à PAC :</translation>
@@ -77,6 +83,8 @@
 				<translation language="French">À PAC :</translation>
 			</element>
 			<element name="CannotFindBuddy">
+			</element>
+			<element name="ErrorContextPrefix">
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="French">Erreur :</translation>
@@ -123,17 +131,23 @@
 			<element name="MarkerTORedTeam">
 				<translation language="French">À : Équipe rouge &gt;</translation>
 			</element>
+			<element name="NeighborsContextPrefix">
+			</element>
 			<element name="NoOneListening">
 				<translation language="French">(Vous êtes trop loin. Vous devriez peut-être crier ?)</translation>
 			</element>
 			<element name="NoOneToReply">
 				<translation language="French">(Il n'y a personne à qui répondre.)</translation>
 			</element>
+			<element name="PrivateContextPrefix">
+			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="French">De </translation>
 			</element>
 			<element name="PrivateSendTo">
 				<translation language="French">À </translation>
+			</element>
+			<element name="SubtitleContextPrefix">
 			</element>
 			<element name="TOPrompt">
 				<translation language="French">À :</translation>

--- a/compiled/dat/KIFrench.loc
+++ b/compiled/dat/KIFrench.loc
@@ -65,10 +65,10 @@
 				<translation language="French">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
-				<translation language="French"> </translation>
+				<translation language="French"></translation>
 			</element>
 			<element name="BroadcastSendTo">
-				<translation language="French"> </translation>
+				<translation language="French"></translation>
 			</element>
 			<element name="BuddiesContextPrefix">
 				<translation language="French">[AMIS] </translation>
@@ -134,6 +134,9 @@
 			</element>
 			<element name="MarkerTORedTeam">
 				<translation language="French">À : Équipe rouge &gt;</translation>
+			</element>
+			<element name="MentionContextPrefix">
+				<translation language="French">[PING] </translation>
 			</element>
 			<element name="NeighborsContextPrefix">
 				<translation language="French">[VOISINS] </translation>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -145,7 +145,7 @@
 				<translation language="German">(Es gibt niemand, dem man antworten könnte.)</translation>
 			</element>
 			<element name="PrivateContextPrefix">
-				<translation language="German">[PRIVATE] </translation>
+				<translation language="German">[PRIVAT] </translation>
 			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="German">Von </translation>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -65,10 +65,10 @@
 				<translation language="German">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
-				<translation language="German"> </translation>
+				<translation language="German"></translation>
 			</element>
 			<element name="BroadcastSendTo">
-				<translation language="German"> </translation>
+				<translation language="German"></translation>
 			</element>
 			<element name="BuddiesContextPrefix">
 				<translation language="German">[FREUNDE] </translation>
@@ -134,6 +134,9 @@
 			</element>
 			<element name="MarkerTORedTeam">
 				<translation language="German">AN: Rotes Team &gt;</translation>
+			</element>
+			<element name="MentionContextPrefix">
+				<translation language="German">[PING] </translation>
 			</element>
 			<element name="NeighborsContextPrefix">
 				<translation language="German">[NACHBARN] </translation>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -61,11 +61,17 @@
 			<element name="AFK">
 				<translation language="German"> (Ich bin an der Oberfläche, komme gleich zurück)</translation>
 			</element>
+			<element name="AdminContextPrefix">
+			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="German"> </translation>
 			</element>
 			<element name="BroadcastSendTo">
 				<translation language="German"> </translation>
+			</element>
+			<element name="BuddiesContextPrefix">
+			</element>
+			<element name="CCRContextPrefix">
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="German">Von %1s an Kundenbetreuung:</translation>
@@ -77,6 +83,8 @@
 				<translation language="German">An Kundenbetreuung:</translation>
 			</element>
 			<element name="CannotFindBuddy">
+			</element>
+			<element name="ErrorContextPrefix">
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="German">Fehler:</translation>
@@ -123,17 +131,23 @@
 			<element name="MarkerTORedTeam">
 				<translation language="German">AN: Rotes Team &gt;</translation>
 			</element>
+			<element name="NeighborsContextPrefix">
+			</element>
 			<element name="NoOneListening">
 				<translation language="German">(Sie sind zu weit weg. Vielleicht sollten Sie schreien.)</translation>
 			</element>
 			<element name="NoOneToReply">
 				<translation language="German">(Es gibt niemand, dem man antworten könnte.)</translation>
 			</element>
+			<element name="PrivateContextPrefix">
+			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="German">Von </translation>
 			</element>
 			<element name="PrivateSendTo">
 				<translation language="German">An </translation>
+			</element>
+			<element name="SubtitleContextPrefix">
 			</element>
 			<element name="TOPrompt">
 				<translation language="German">AN:</translation>

--- a/compiled/dat/KIGerman.loc
+++ b/compiled/dat/KIGerman.loc
@@ -62,6 +62,7 @@
 				<translation language="German"> (Ich bin an der Oberfläche, komme gleich zurück)</translation>
 			</element>
 			<element name="AdminContextPrefix">
+				<translation language="German">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="German"> </translation>
@@ -70,8 +71,10 @@
 				<translation language="German"> </translation>
 			</element>
 			<element name="BuddiesContextPrefix">
+				<translation language="German">[FREUNDE] </translation>
 			</element>
 			<element name="CCRContextPrefix">
+				<translation language="German">[KUNDENBETREUUNG] </translation>
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="German">Von %1s an Kundenbetreuung:</translation>
@@ -85,6 +88,7 @@
 			<element name="CannotFindBuddy">
 			</element>
 			<element name="ErrorContextPrefix">
+				<translation language="German">[FEHLER] </translation>
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="German">Fehler:</translation>
@@ -132,6 +136,7 @@
 				<translation language="German">AN: Rotes Team &gt;</translation>
 			</element>
 			<element name="NeighborsContextPrefix">
+				<translation language="German">[NACHBARN] </translation>
 			</element>
 			<element name="NoOneListening">
 				<translation language="German">(Sie sind zu weit weg. Vielleicht sollten Sie schreien.)</translation>
@@ -140,6 +145,7 @@
 				<translation language="German">(Es gibt niemand, dem man antworten könnte.)</translation>
 			</element>
 			<element name="PrivateContextPrefix">
+				<translation language="German">[PRIVATE] </translation>
 			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="German">Von </translation>
@@ -148,6 +154,7 @@
 				<translation language="German">An </translation>
 			</element>
 			<element name="SubtitleContextPrefix">
+				<translation language="German">[UNTERTITEL] </translation>
 			</element>
 			<element name="TOPrompt">
 				<translation language="German">AN:</translation>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -55,11 +55,17 @@
 			<element name="AFK">
 				<translation language="Italian"> (Sono in superficie, torno tra un minuto)</translation>
 			</element>
+			<element name="AdminContextPrefix">
+			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="Italian"> </translation>
 			</element>
 			<element name="BroadcastSendTo">
 				<translation language="Italian"> </translation>
+			</element>
+			<element name="BuddiesContextPrefix">
+			</element>
+			<element name="CCRContextPrefix">
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="Italian">Da %1s a Assistenza:</translation>
@@ -71,6 +77,8 @@
 				<translation language="Italian">A Assistenza:</translation>
 			</element>
 			<element name="CannotFindBuddy">
+			</element>
+			<element name="ErrorContextPrefix">
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="Italian">Errore:</translation>
@@ -117,17 +125,23 @@
 			<element name="MarkerTORedTeam">
 				<translation language="Italian">A: Squadra Rossa &gt;</translation>
 			</element>
+			<element name="NeighborsContextPrefix">
+			</element>
 			<element name="NoOneListening">
 				<translation language="Italian">(Sei troppo lontano, forse è meglio gridare.)</translation>
 			</element>
 			<element name="NoOneToReply">
 				<translation language="Italian">(Non c'è nessuno con cui parlare.)</translation>
 			</element>
+			<element name="PrivateContextPrefix">
+			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="Italian">Da </translation>
 			</element>
 			<element name="PrivateSendTo">
 				<translation language="Italian">A </translation>
+			</element>
+			<element name="SubtitleContextPrefix">
 			</element>
 			<element name="TOPrompt">
 				<translation language="Italian">A:</translation>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -56,6 +56,7 @@
 				<translation language="Italian"> (Sono in superficie, torno tra un minuto)</translation>
 			</element>
 			<element name="AdminContextPrefix">
+				<translation language="Italian">[AMMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="Italian"> </translation>
@@ -64,8 +65,10 @@
 				<translation language="Italian"> </translation>
 			</element>
 			<element name="BuddiesContextPrefix">
+				<translation language="Italian">[AMICI] </translation>
 			</element>
 			<element name="CCRContextPrefix">
+				<translation language="Italian">[ASSISTENZA] </translation>
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="Italian">Da %1s a Assistenza:</translation>
@@ -79,6 +82,7 @@
 			<element name="CannotFindBuddy">
 			</element>
 			<element name="ErrorContextPrefix">
+				<translation language="Italian">[ERRORE] </translation>
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="Italian">Errore:</translation>
@@ -126,6 +130,7 @@
 				<translation language="Italian">A: Squadra Rossa &gt;</translation>
 			</element>
 			<element name="NeighborsContextPrefix">
+				<translation language="Italian">[VICINI] </translation>
 			</element>
 			<element name="NoOneListening">
 				<translation language="Italian">(Sei troppo lontano, forse è meglio gridare.)</translation>
@@ -134,6 +139,7 @@
 				<translation language="Italian">(Non c'è nessuno con cui parlare.)</translation>
 			</element>
 			<element name="PrivateContextPrefix">
+				<translation language="Italian">[PRIVATO] </translation>
 			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="Italian">Da </translation>
@@ -142,6 +148,7 @@
 				<translation language="Italian">A </translation>
 			</element>
 			<element name="SubtitleContextPrefix">
+				<translation language="Italian">[SOTTOTITOLO] </translation>
 			</element>
 			<element name="TOPrompt">
 				<translation language="Italian">A:</translation>

--- a/compiled/dat/KIItalian.loc
+++ b/compiled/dat/KIItalian.loc
@@ -59,10 +59,10 @@
 				<translation language="Italian">[AMMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
-				<translation language="Italian"> </translation>
+				<translation language="Italian"></translation>
 			</element>
 			<element name="BroadcastSendTo">
-				<translation language="Italian"> </translation>
+				<translation language="Italian"></translation>
 			</element>
 			<element name="BuddiesContextPrefix">
 				<translation language="Italian">[AMICI] </translation>
@@ -128,6 +128,9 @@
 			</element>
 			<element name="MarkerTORedTeam">
 				<translation language="Italian">A: Squadra Rossa &gt;</translation>
+			</element>
+			<element name="MentionContextPrefix">
+				<translation language="Italian">[PING] </translation>
 			</element>
 			<element name="NeighborsContextPrefix">
 				<translation language="Italian">[VICINI] </translation>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -56,6 +56,7 @@
 				<translation language="Spanish"> (Estoy en la superficie, volveré en un minuto)</translation>
 			</element>
 			<element name="AdminContextPrefix">
+				<translation language="Spanish">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="Spanish"> </translation>
@@ -64,8 +65,10 @@
 				<translation language="Spanish"> </translation>
 			</element>
 			<element name="BuddiesContextPrefix">
+				<translation language="Spanish">[AMIGOS] </translation>
 			</element>
 			<element name="CCRContextPrefix">
+				<translation language="Spanish">[CCR] </translation>
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="Spanish">De %1s a CCR:</translation>
@@ -79,6 +82,7 @@
 			<element name="CannotFindBuddy">
 			</element>
 			<element name="ErrorContextPrefix">
+				<translation language="Spanish">[ERROR] </translation>
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="Spanish">Error:</translation>
@@ -126,6 +130,7 @@
 				<translation language="Spanish">A: El equipo rojo &gt;</translation>
 			</element>
 			<element name="NeighborsContextPrefix">
+				<translation language="Spanish">[SECTORES] </translation>
 			</element>
 			<element name="NoOneListening">
 				<translation language="Spanish">(Estás demasiado lejos, ¿quizás si subes la voz?)</translation>
@@ -134,6 +139,7 @@
 				<translation language="Spanish">(No hay nadie a quien responder.)</translation>
 			</element>
 			<element name="PrivateContextPrefix">
+				<translation language="Spanish">[PRIVADO] </translation>
 			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="Spanish">De </translation>
@@ -142,6 +148,7 @@
 				<translation language="Spanish">A </translation>
 			</element>
 			<element name="SubtitleContextPrefix">
+				<translation language="Spanish">[SUBTÍTULO] </translation>
 			</element>
 			<element name="TOPrompt">
 				<translation language="Spanish">A:</translation>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -59,10 +59,10 @@
 				<translation language="Spanish">[ADMIN] </translation>
 			</element>
 			<element name="BroadcastMsgRecvd">
-				<translation language="Spanish"> </translation>
+				<translation language="Spanish"></translation>
 			</element>
 			<element name="BroadcastSendTo">
-				<translation language="Spanish"> </translation>
+				<translation language="Spanish"></translation>
 			</element>
 			<element name="BuddiesContextPrefix">
 				<translation language="Spanish">[AMIGOS] </translation>
@@ -128,6 +128,9 @@
 			</element>
 			<element name="MarkerTORedTeam">
 				<translation language="Spanish">A: El equipo rojo &gt;</translation>
+			</element>
+			<element name="MentionContextPrefix">
+				<translation language="Spanish">[PING] </translation>
 			</element>
 			<element name="NeighborsContextPrefix">
 				<translation language="Spanish">[SECTORES] </translation>

--- a/compiled/dat/KISpanish.loc
+++ b/compiled/dat/KISpanish.loc
@@ -55,11 +55,17 @@
 			<element name="AFK">
 				<translation language="Spanish"> (Estoy en la superficie, volveré en un minuto)</translation>
 			</element>
+			<element name="AdminContextPrefix">
+			</element>
 			<element name="BroadcastMsgRecvd">
 				<translation language="Spanish"> </translation>
 			</element>
 			<element name="BroadcastSendTo">
 				<translation language="Spanish"> </translation>
+			</element>
+			<element name="BuddiesContextPrefix">
+			</element>
+			<element name="CCRContextPrefix">
 			</element>
 			<element name="CCRFromPlayer">
 				<translation language="Spanish">De %1s a CCR:</translation>
@@ -71,6 +77,8 @@
 				<translation language="Spanish">A CCR:</translation>
 			</element>
 			<element name="CannotFindBuddy">
+			</element>
+			<element name="ErrorContextPrefix">
 			</element>
 			<element name="ErrorMsgRecvd">
 				<translation language="Spanish">Error:</translation>
@@ -117,17 +125,23 @@
 			<element name="MarkerTORedTeam">
 				<translation language="Spanish">A: El equipo rojo &gt;</translation>
 			</element>
+			<element name="NeighborsContextPrefix">
+			</element>
 			<element name="NoOneListening">
 				<translation language="Spanish">(Estás demasiado lejos, ¿quizás si subes la voz?)</translation>
 			</element>
 			<element name="NoOneToReply">
 				<translation language="Spanish">(No hay nadie a quien responder.)</translation>
 			</element>
+			<element name="PrivateContextPrefix">
+			</element>
 			<element name="PrivateMsgRecvd">
 				<translation language="Spanish">De </translation>
 			</element>
 			<element name="PrivateSendTo">
 				<translation language="Spanish">A </translation>
+			</element>
+			<element name="SubtitleContextPrefix">
 			</element>
 			<element name="TOPrompt">
 				<translation language="Spanish">A:</translation>


### PR DESCRIPTION
Primarily for use in chat logs for easier post-processing, e.g., to remove private messages or subtitles before posting chat logs to a forum post or blog or whatnot.

Will also turn on automatically for now when the user has used `/textcolor` to override default header color to indicate the chat context (I, for one, can never remember what the colors mean, though).

Sibling Plasma PR Coming Soon(TM).