### PR TITLE
Add .vs folder to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.blend1
 *.ktc
 *.pyc
+
+# Visual Studio cache/options directory
+.vs/


### PR DESCRIPTION
Make sure to ignore the silly .vs folder because sometimes I'm a weirdo and edit LOCs in Visual Studio. Sometimes I like the VS compare better than a command-line `git diff`. 🤷 