### PR TITLE
Garrison Updates to Match Moula Q2

### DIFF
--- a/compiled/dat/Garrison_District_NexusBlackRoom.prp
+++ b/compiled/dat/Garrison_District_NexusBlackRoom.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:86b6a60f8d8d8b3c11c6fe5e4ab6b7a77c0bd1c950ea4f880362af89662f468d
-size 1918368
+oid sha256:ceacfc5e1c765471c551bd52220bf344255bb0351153068fd961dd5d201b4146
+size 1929807

--- a/compiled/dat/Garrison_District_NexusWhiteRoom.prp
+++ b/compiled/dat/Garrison_District_NexusWhiteRoom.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4cd50c1ad4431aba8e44b554bee7785fa8acf3d92fe1b9d399f98f49abccf056
-size 1986604
+oid sha256:38ffef6c2b7f04f87f86c6901e75a860475fa991b567ef7513cb1e92874195ce
+size 1998043

--- a/compiled/dat/Garrison_District_WallAdditions.prp
+++ b/compiled/dat/Garrison_District_WallAdditions.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d6c996a2fed67dd4f5eeceef98c6a1ba8fcec76584ef42b1ac011b996d11425
-size 61540
+oid sha256:1d3af6f47055a80545f75b9f7d93006d781d4f723b1a78cbb77b8900922fcffb
+size 62128

--- a/compiled/dat/Garrison_District_grsnObsRoom01Imager.prp
+++ b/compiled/dat/Garrison_District_grsnObsRoom01Imager.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:30259cf8e08a7246d50ddd28d6d0d274cda4227d4f5b1facc689e82850c0bd64
-size 1257353
+oid sha256:64d41c3fb23a94e1cae832b53977cdb00ae1870de2d8d6b4ea2a79e170d7f1a0
+size 1257348

--- a/compiled/dat/Garrison_District_grsnObsRoom02Imager.prp
+++ b/compiled/dat/Garrison_District_grsnObsRoom02Imager.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e8e09eaeb6a8d773b58cf11dfa3b7a1b0da57bb065061ddc164bbf2c99777d2
-size 1247777
+oid sha256:15ee30368c949855e5654663f94c9899bc12be880cb7f10129a59f792d8693f6
+size 1247774

--- a/compiled/dat/Garrison_District_grsnWallRoomClimbingPhys.prp
+++ b/compiled/dat/Garrison_District_grsnWallRoomClimbingPhys.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc0056613dcf9d6804b79cc0ed43fc487c5c66078470a1543c0ed507407d23da
+oid sha256:de529f75eb0b3e06c5da1e2a270b5726ca589e05c27e986fce9be4984a36a4d6
 size 4825732

--- a/compiled/dat/Garrison_District_grsnWallRoomClimbingPhys.prp
+++ b/compiled/dat/Garrison_District_grsnWallRoomClimbingPhys.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a198a016afa41377802fc4af30187268f9b2ce0878a0d003050db2e8c1d9f2f
-size 4824875
+oid sha256:cc0056613dcf9d6804b79cc0ed43fc487c5c66078470a1543c0ed507407d23da
+size 4825732

--- a/compiled/dat/Garrison_District_trainingCenterObservationRooms.prp
+++ b/compiled/dat/Garrison_District_trainingCenterObservationRooms.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe60252e96eef69500fdc49a143bead646169f430b01eed5792d551395b1c13d
-size 1080884
+oid sha256:e25b44f8160ff5ce64bd585ff3d8f101124cb17f4255b92bfbcd78d4fa5a4d06
+size 1080879


### PR DESCRIPTION
Removed panel red lights fade out and back in when they are used, makes the blocker counters look a little better.
Made blocker screens not flicker anymore and half as transparant.
Flashing lights when book deploys now flash half as slow but the entire time the book is out
Made Building 2 map screen in conference rooms not flicker anymore and half as transparant.
Added visregions to all wall viewer screens in observation rooms to help with age lag
Reduced static opacity for observer rooms and nexi
Fixed the Green Button animations for both panels
Fixed bug with when the green buttons were supposed to be able to be clicked