### PR TITLE
French Uru credits in alignment with English contents

### DIFF
--- a/compiled/dat/GlobalEnglish.loc
+++ b/compiled/dat/GlobalEnglish.loc
@@ -265,8 +265,7 @@ Sound Implementation
 <font size=26><p align=center>Additional Cyan Development<font spacing=-5>
 <font size=24 spacing=-10>Taylor Bailey, Ocala Bellows, Aaron Biegalski, Bryce J. Biggerstaff, John Brooks, Bryan Bussard, T. Elliot Cannon, Bret Carlson, Tim S. DeWolf, Eric Ellis, Scott Ellwanger, Mark Engberg/Colab, Brad Halpin, Keely Honeywell, Daniel Johnston, Gil Keppler, Brandon A. Knowles, Jeff Oswalt, Ryan B. Persch, Melinda Russel, Thom Schillinger, Micah Sheets, Lee Sheldon, Tyler J. Smith, Craig Voigt, Zachary M. Wellsandt, Maureen Wick
 
-<pb>
-<font size=26><p align=center>Special Thanks To<font spacing=-5>
+<pb><font size=26><p align=center>Special Thanks To<font spacing=-5>
 <font size=24 spacing=-10><p align=center>
 Blake Lewin
 Roger Faso
@@ -346,14 +345,14 @@ https://github.com/kcat/openal-soft
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>OpenSSL
-Copyright (c) 1998-2019 The OpenSSL Project.  All rights reserved.
+Copyright (c) 1998-2019 The OpenSSL Project. All rights reserved.
 This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)
 This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).
-This product includes software written by Tim  Hudson (tjh@cryptsoft.com).
+This product includes software written by Tim Hudson (tjh@cryptsoft.com).
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>Opus
-Copyright 2001-2011 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding,Erik de Castro Lopo
+Copyright 2001-2011 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo
 https://www.opus-codec.org
 
 <font spacing=-18>

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -288,7 +288,7 @@ Certains sons et enregistrements vocaux sont fournis par The Friends of Sironka 
 <font size=24 spacing=-10><p align=center>FaceGen Modeller 2.1
 Singular Inversions, Inc.
 <font spacing=-18>
-<font size=24 spacing=-10><p align=center>Artbeats Digital Film Library
+<font size=24 spacing=-10><p align=center>Bibliothèque de films numériques Artbeats
 Artbeats
 
 <pb><font size=26><p align=center>Licences Open Source<font spacing=-5>

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -195,7 +195,7 @@
 <p align=left>Jeff Lundin<p align=right>Programmation du client
 <p align=left>Jason M. Calvert<p align=right>Programmation du client
 <p align=left>Adam Van Ornum<p align=right>Programmation du client
-<p align=left>Randy Ridgway<p align=right>Programmeur physiques
+<p align=left>Randy Ridgway<p align=right>Programmeur physique
 <p align=left>Chris Doyle<p align=right>Graphiste technique Sr.
 <p align=left>Derek Odell<p align=right>Graphiste technique, Jouabilité
 <p align=left>Tye Hooley<p align=right>Graphiste technique, Jouabilité
@@ -213,7 +213,7 @@ Implémentation Audio
 <font size=26><p align=center>Musique et sons<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Tim Larkin<p align=right>Conception sonore, musique
 
-<font size=26><p align=center>Conception et commandes<font spacing=-5>
+<font size=26><p align=center>Conception et contrôle<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Richard A. Watson<p align=right>Historien des D'ni, Conception
 <p align=left>Ryan S. J. Miller<p align=right>Responsable de la conception
 du jeu
@@ -246,11 +246,11 @@ du jeu
 <p align=left>Mark Dobratz<p align=right>Chef de projet
 <p align=left>Susan R. Bonds<p align=right>Co-Productrice
 <p align=left>Mark Klammer<p align=right>Directeur financier
-<p align=left>Dave Smith<p align=right>Responsable du informatique
+<p align=left>Dave Smith<p align=right>Responsable de l'informatique
 <p align=left>Byron R. Heinemann<p align=right>Maintenance & surprises
 <p align=left>Eloise McCloskey<p align=right>Comptabilité
 
-<font size=26 spacing=-18><p align=center>Acteurs voix<font spacing=-5>
+<font size=26 spacing=-18><p align=center>Artistes vocal<font spacing=-5>
 <font size=24 spacing=-10><p align=center>Xavier Kemmlein (France)<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Bernard Bollet<p align=right>Atrus
 <p align=left>Nathalie Homs<p align=right>Yeesha
@@ -315,7 +315,7 @@ https://github.com/anholt/libepoxy
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>libjpeg-turbo
-This software is based in part on the work of the Independent JPEG Group.
+Ce logiciel est basé en partie sur le travail de l'Independent JPEG Group.
 Copyright (C)2009-2021 D. R. Commander. Tous droits réservés.
 Copyright (C)2015 Viktor Szathmáry. Tous droits réservés.
 https://libjpeg-turbo.org
@@ -351,9 +351,9 @@ https://github.com/kcat/openal-soft
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>OpenSSL
 Copyright (c) 1998-2019 The OpenSSL Project. Tous droits réservés.
-This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)
-This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).
-This product includes software written by Tim  Hudson (tjh@cryptsoft.com).
+Ce produit inclut un logiciel développé par le OpenSSL Project pour une utilisation dans OpenSSL Toolkit (http://www.openssl.org/)
+Ce produit comprend un logiciel cryptographique écrit par Eric Young (eay@cryptsoft.com).
+Ce produit comprend un logiciel écrit par Tim Hudson (tjh@cryptsoft.com).
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>Opus

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -189,7 +189,7 @@
 <font size=24 spacing=-10><p align=left>Rand Miller<p align=right>Directeur
 
 <p align=center>Programmation<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Mark H. DeForest<p align=right>CTO
+<font size=24 spacing=-10><p align=left>Mark H. DeForest<p align=right>Directeur de la Technologie
 <p align=left>Bob Zasio<p align=right>Programmeur graphique principal
 <p align=left>Eric S. Anderson<p align=right>Programmeur serveur principal
 <p align=left>Jeff Lundin<p align=right>Programmation du client

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -237,9 +237,9 @@ du jeu
 <p align=left>Chris Lambert<p align=right>Service Client
 <p align=left>Bob Mathias<p align=right>Service Client
 <p align=left>Emily Norton<p align=right>Service Client
-<p align=left>Bradford Chapman<p align=right>Testeur
-<p align=left>John Taitingfong<p align=right>Testeur
-<p align=left>Eliza Wyatt<p align=right>Testeuse
+<p align=left>Bradford Chapman<p align=right>Testeur AQ
+<p align=left>John Taitingfong<p align=right>Testeur AQ
+<p align=left>Eliza Wyatt<p align=right>Testeuse AQ
 
 <font size=26><p align=center>Support administratif<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Tony Fryman<p align=right>Président
@@ -259,8 +259,8 @@ du jeu
 
 <pb><font size=26><p align=center>Musiciens<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Eric Engerbretson<p align=right>Guitare
-<p align=left>Friends of Sironka Dance Troupe<p align=right>Choeurs
-<p align=left>Tasha Koontz<p align=right>Voix
+<p align=left>Friends of Sironka Dance Troupe<p align=right>Chanteurs
+<p align=left>Tasha Koontz<p align=right>Chanteuse
 
 <font size=26><p align=center>Remerciements spéciaux aux premiers développeurs d'Uru<font spacing=-5>
 <font size=24 spacing=-10><p align=center>Ryan Allred, James Beattie, John M. Biggs, Susan R. Bonds, Colin Bonstead, Chris Brandkamp, Mathew C. Burrack, Gary W. Butcher, Christopher L. Clanin, Terry J. Coolidge, Mark T. Finch, Robert J. Emanuele, Peter Gage, Paul Gallagher, Robert Grace, Mike Hines, Steve Hoogendyk, Tricia (Bland) Kinder, Brian Kulig, Stephan Martiniere, Matthew B. MacLaurin, Douglas T. McBride, Steve Ogden, Christian Piccolo, Chris J. Purvis, Paul A. Querna, Nathan Reidt, Terry Schmidbauer, Bill Slease, Rod Stafford, Mark Stenersen
@@ -271,7 +271,7 @@ du jeu
 <font size=26><p align=center>Développement Supplémentaire de Cyan<font spacing=-5>
 <font size=24 spacing=-10>Taylor Bailey, Ocala Bellows, Aaron Biegalski, Bryce J. Biggerstaff, John Brooks, Bryan Bussard, T. Elliot Cannon, Bret Carlson, Tim S. DeWolf, Eric Ellis, Scott Ellwanger, Mark Engberg/Colab, Brad Halpin, Keely Honeywell, Daniel Johnston, Gil Keppler, Brandon A. Knowles, Jeff Oswalt, Ryan B. Persch, Melinda Russel, Thom Schillinger, Micah Sheets, Lee Sheldon, Tyler J. Smith, Craig Voigt, Zachary M. Wellsandt, Maureen Wick
 
-<pb><font size=26><p align=center>Un Merci Spécial à<font spacing=-5>
+<pb><font size=26><p align=center>Remerciement Spécial à<font spacing=-5>
 <font size=24 spacing=-10><p align=center>
 Blake Lewin
 Roger Faso
@@ -282,7 +282,7 @@ Celia Pearce
 <pb><font size=26><p align=center>Légal<font spacing=-5>
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>Friends of Sironka Dance Troupe
-Certains sons et certains enregistrements vocaux sont fournis par The Friends of Sironka Dance Troupe, sous licence non-exclusive de Cyan, utilisé avec leur autorisation.
+Certains sons et enregistrements vocaux sont fournis par The Friends of Sironka Dance Troupe, sous licence nonexclusive de Cyan, utilisé avec leur autorisation.
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>FaceGen Modeller 2.1

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -185,332 +185,200 @@
 		</set>
 		<set name="Journals">
 			<element name="URUCredits">
-				<translation language="French"><![CDATA[<cover src="xUruCreditsJournalCover*1#0.hsm"><font face=Uru size=24 spacing=-10 color=000000><margin right=32 left=32 top=22 bottom=23><p align=left><font size=26><p align=center>Programmation<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Mark T. Finch<p align=right>Graphisme, Architecture principale
-<p align=left>Mark H. DeForest<p align=right>Interface Python
-<p align=left>Mustafa Thamer<p align=right>Réseau, Serveurs de jeu
-<p align=left>Robert J. Emanuele<p align=right>Réseau, Systèmes
-<p align=left>Colin Bonstead<p align=right>Outils physiques
-<p align=left>Chris J. Purvis<p align=right>Programmation du client
-<p align=left>Bob Zasio<p align=right>Animations des avatars
-<p align=left>Eric S. Anderson<p align=right>Bases de données, Serveurs de jeu
-<p align=left>Jeff Lundin<p align=right>Script de l'Interface
-<p align=left>Jason M. Calvert<p align=right>Audio
-<p align=left>Mathew C. Burrack<p align=right>Interface audio
-<p align=left>Matthew B. MacLaurin<p align=right>Comportement des avatars
-<p align=left>Paul A. Querna<p align=right>Outils
-<p align=left>Harvey Chapman<p align=right>Systèmes
+				<translation language="French"><![CDATA[<cover src="xUruCreditsJournalCover*1#0.hsm"><font face=Uru size=24 spacing=-10 color=000000><margin right=32 left=32 top=22 bottom=23><p align=left><font size=26><p align=center>Vision<font spacing=-5>
+<font size=24 spacing=-10><p align=left>Rand Miller<p align=right>Directeur
+
+<p align=center>Programmation<font spacing=-5>
+<font size=24 spacing=-10><p align=left>Mark H. DeForest<p align=right>CTO
+<p align=left>Bob Zasio<p align=right>Programmeur graphique principal
+<p align=left>Eric S. Anderson<p align=right>Programmeur serveur principal
+<p align=left>Jeff Lundin<p align=right>Programmation du client
+<p align=left>Jason M. Calvert<p align=right>Programmation du client
+<p align=left>Adam Van Ornum<p align=right>Programmation du client
+<p align=left>Randy Ridgway<p align=right>Programmeur physiques
+<p align=left>Chris Doyle<p align=right>Graphiste technique Sr.
+<p align=left>Derek Odell<p align=right>Graphiste technique, Jouabilité
+<p align=left>Tye Hooley<p align=right>Graphiste technique, Jouabilité
+Implémentation Audio
+<p align=left>Karl Johnson<p align=right>Graphiste technique, Jouabilité
 <font spacing=-18>
-<font size=26><p align=center>Modélisation des mondes<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Douglas T. McBride<p align=right>Graphiste technique Sr.
-<p align=left>Chris Doyle<p align=right>Graphiste technique
-<p align=left>Adam Van Ornum<p align=right>Graphiste technique
+
 <pb><font size=26><p align=center>Graphismes<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Josh Staub<p align=right>Direction artistique
 <p align=left>Jason C. Baskett<p align=right>Responsable de l'animation
-<p align=left>Eric R. Warman<p align=right>Graphiste
 <p align=left>Austin Thomas<p align=right>Graphiste
 <p align=left>Victoria Brace<p align=right>Graphiste
-<p align=left>Gary W. Butcher<p align=right>Graphiste
-<p align=left>Terry J. Coolidge<p align=right>Graphiste
 <p align=left>Eric A. Anderson<p align=right>Responsable des graphismes
-<p align=left>Rod Stafford<p align=right>Responsable des avatars
-<p align=left>Steve Ogden<p align=right>Responsable des graphismes
-<p align=left>Steve Hoogendyk<p align=right>Conception des graphismes
-<p align=left>Jeff Wilson<p align=right>Animateur
-<p align=left>Mike Hines<p align=right>Responsable des graphismes
-<p align=left>Mark Stenersen<p align=right>Avatar
-<font spacing=-18>
+
 <font size=26><p align=center>Musique et sons<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Tim Larkin<p align=right>Conception sonore, musique
-<p align=left>Christopher L. Clanin<p align=right>Conception sonore, arrangements
-<pb><font size=26><p align=center>Control Freaks<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Rand Miller<p align=right>Directeur
-<p align=left>Brice Tebbs<p align=right>Producteur
-<font spacing=-18>
-<font size=26><p align=center>Assurance Qualité<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Eric G. Votava<p align=right>Responsable des ingénieurs AQ
-<p align=left>Lloyd Bell<p align=right>Responsable de l'AQ
-<p align=left>Ryan B. Persch<p align=right>Responsable du test
-<p align=left>Greg J. Miranda<p align=right>Responsable du test
-<p align=left>Micah Sheets<p align=right>Testeur
-<p align=left>Victoria L. Almond<p align=right>Testeuse
-<p align=left>Aaron Biegalski<p align=right>Testeur
-<p align=left>Bryce J. Biggerstaff<p align=right>Testeur
-<p align=left>Tim S. DeWolf<p align=right>Testeur
-<p align=left>Brandon A. Knowles<p align=right>Testeur
-<p align=left>Bryan Bussard<p align=right>Testeur
-<p align=left>Derek Odell<p align=right>Testeur
-<p align=left>Zachary M. Wellsandt<p align=right>Testeur
-<p align=left>Tyler J. Smith<p align=right>Testeur
-<pb><font size=26><p align=center>Conception et commandes<font spacing=-5>
+
+<font size=26><p align=center>Conception et commandes<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Richard A. Watson<p align=right>Historien des D'ni, Conception
-<p align=left>Ryan S. J. Miller<p align=right>Responsable de la conception du jeu
-<p align=left>Bill Slease<p align=right>Directeur du contenu en ligne
-<p align=left>Stephan Martiniere<p align=right>Dir. de la conception artistique
-<p align=left>Patti VanHeel<p align=right>Web, Rédactrice technique
-<p align=left>Ryan J. Warzecha<p align=right>Analyste du contenu en ligne
+<p align=left>Ryan S. J. Miller<p align=right>Responsable de la conception
+du jeu
+<p align=left>Ryan J. Warzecha<p align=right>Chef de communauté
 <font spacing=-18>
+
+<pb><font size=26><p align=center>Assurance Qualité et Service Client<font spacing=-5>
+<font size=24 spacing=-10><p align=left>Lloyd Bell<p align=right>Directeur de l'AQ
+<p align=left>Greg J. Miranda<p align=right>Responsable de l'AQ et SC
+<p align=left>Victoria L. Almond<p align=right>Responsable de l'AQ et SC
+<p align=left>Karl Johnson<p align=right>Responsable de l'AQ et SC
+/ Développeur Web Sr.
+<p align=left>Aaron Biegalski<p align=right>Responsable du SC
+<p align=left>M. Wolf Cowart<p align=right>Responsable du SC
+<p align=left>Michael Dogherra<p align=right>Responsable du SC
+<p align=left>Brandon Knowles<p align=right>Responsable du SC
+<p align=left>Kerryn Miller<p align=right>Responsable du SC
+<p align=left>Taylor Bailey<p align=right>Service Client
+<p align=left>Jesse Bronson<p align=right>Service Client
+<p align=left>Ben Drechsel<p align=right>Service Client
+<p align=left>Chris Lambert<p align=right>Service Client
+<p align=left>Bob Mathias<p align=right>Service Client
+<p align=left>Emily Norton<p align=right>Service Client
+<p align=left>Bradford Chapman<p align=right>Testeur
+<p align=left>John Taitingfong<p align=right>Testeur
+<p align=left>Eliza Wyatt<p align=right>Testeuse
+
 <font size=26><p align=center>Support administratif<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Tony Fryman<p align=right>Président
 <p align=left>Mark Dobratz<p align=right>Chef de projet
 <p align=left>Susan R. Bonds<p align=right>Co-Productrice
-<p align=left>Chris Brandkamp<p align=right>VP Business
-<p align=left>John M. Biggs<p align=right>Responsable des systèmes
 <p align=left>Mark Klammer<p align=right>Directeur financier
+<p align=left>Dave Smith<p align=right>Responsable du informatique
 <p align=left>Byron R. Heinemann<p align=right>Maintenance & surprises
 <p align=left>Eloise McCloskey<p align=right>Comptabilité
-<pb><font size=26><p align=center>Développement supplémentaire<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Peter Gage<p align=right>Graphiste technique
-<p align=left>William Stoneham<p align=right>Graphiste cinématiques
-<p align=left>James Beattie<p align=right>Programmation
-<p align=left>Nathan Reidt<p align=right>Graphiste cinématiques
-<p align=left>Christian Piccolo<p align=right>Concepteur
-<p align=left>Robert Grace<p align=right>Concepteur
-<p align=left>Ryan Allred<p align=right>Programmation
-<p align=left>Jeff Oswalt<p align=right>Communications
-<p align=left>Tricia (Bland) Kinder<p align=right>Assistante administrative
-<p align=left>Paul Gallagher<p align=right>Programmation
-<p align=left>Brian Kulig<p align=right>Graphiste cinématiques
-<p align=left>Kyle Wilson<p align=right>Programmation
-<p align=left>Terry Schmidbauer<p align=right>Graphiste cinématiques
-<p align=left>Adrian Stone<p align=right>Programmation
-<p align=left>T. Elliot Cannon<p align=right>Concepteur
-<p align=left>Craig Voigt<p align=right>Graphiste cinématiques
-<p align=left>Eric Ellis<p align=right>Programmation
-<p align=left>John Brooks<p align=right>AQ
-<p align=left>Brad Halpin<p align=right>Programmation
-<pb><font size=26><p align=center>Développement supplémentaire (suite.)<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Scott Ellwanger<p align=right>Stagiaire AQ
-<p align=left>Bret Carlson<p align=right>Stagiaire conception
-<font spacing=-18>
-<font size=26><p align=center>Prestataires indépendents<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Ocala Bellows<p align=right>Conception
-<p align=left>Mark Engberg/Colab<p align=right>Conception de l'architecture
-<p align=left>Thom Schillinger<p align=right>Conception graphique
-<p align=left>Lee Sheldon<p align=right>Conception de l'histoire
-<p align=left>Gil Keppler<p align=right>Conception graphique
-<font spacing=-18>
-<font size=26><p align=center>Acteurs voix<font spacing=-5>
-<font size=24 spacing=-10><p align=left>David Ogden Stiers<p align=right>Zandi
-<p align=left>Rengin Altay<p align=right>Yeesha
-<font spacing=-18>
-<font size=26><p align=center>Musiciens<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Eric Engerbretson<p align=right>Guitare
-<p align=left>Friends of Sironka Dance Troupe<p align=right>Choeurs
-<p align=left>Charlie Adelphia<p align=right>Doudouk
-<p align=left>Tasha Koontz<p align=right>Voix
-<pb><font size=26><p align=center>Premiers explorateurs<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Richard Warman<p align=right>Rico
-<p align=left>Michael J. Jones<p align=right>IMForeman
-<p align=left>J. Patrick Greer<p align=right>Dr. Greer
-<p align=left>Melinda Russell<p align=right>Rivenchan
-<p align=left>Catherine Reymond<p align=right>BlasterCalm
-<font spacing=-18>
-<font size=26><p align=center>Test supplémentaire<font spacing=-5>
-<font size=24 spacing=-10><p align=center>Robyn Miller
-Alex Miller
-Kevin Bishopp
-Jody Bishopp
-Adam Breeden
-Dave Clark
-Travis Hanson
-Jason Hanson
-Lloyd Woodall
-Paul O'Russa
-Mark VanDyke
-<pb><font size=26><p align=center>Un grand merci à<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Jeff Zandi<p align=right>Preafter
-<p align=left>Yves Guillemot<p align=right>Ubisoft
-<p align=left>Gilles Langourieux<p align=right>Ubisoft
-<p align=left>Joe Ybarra<p align=right>Ubisoft
-<p align=left>Sébastien Puel<p align=right>Ubisoft
-<p align=left>Masami Maeda<p align=right>Sunsoft
-<p align=left>Épouses et familles	
-<p align=left>Eloise, Dana, Debbie<p align=right>La Guilde des Traiteurs
-<p align=left>Jeff Shelby	
-<p align=left>Dan Adler	
-<p align=left>Chuck Hirsch	
-<p align=left>Michelle, et al<p align=right>Out West Espresso
-<p align=left>Arnaldo Roman
 
-<font size=24><p align=center>Remerciements tout particuliers à plus de 4,000+ Beta-Testeurs !
-<font size=26><p align=center>Crédits supplémentaires à 
-www.cyan.com/urucredits
-
-<pb><font size=26><p align=center>Ubisoft<font spacing=-5>
-<font size=24 spacing=-10><p align=center>Gilles Langourieux
-Responsable en chef d'Ubi.com (Monde)
-<font spacing=-18>
-<font size=24 spacing=-10><p align=center>Joe Ybarra
-VP de Production<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Sébastien Puel<p align=right>Producteur
-<p align=left>Erik Zwerling<p align=right>Producteur
-<p align=left>Jean-Christophe Pelletier<p align=right>Assistant de production
-<p align=left>Patricia A. Pizer<p align=right>Analyste de jeu Senior
-<p align=left>Pierre Rivest<p align=right>Analyste de jeu
-<p align=left>Katherine Postma<p align=right>Responsable de communauté
-<font spacing=-18>
-<font size=24 spacing=-10><p align=center>Un grand merci à Jean-Marc Broyer.
-<font spacing=-18>
-<font size=26><p align=center>Équipe Support clientèle<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Marc-Alexandre Plouffe<p align=right>Responsable SC
-<p align=left>Jason Di Valerio<p align=right>SC
-<p align=left>Jessica Fortin<p align=right>SC
-<p align=left>Simon Cuccioletta<p align=right>SC
-<pb><font size=26><p align=center>Responsables Support clientèle<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Daniel Germain<p align=right>Mode solo
-<p align=left>Michael Morehouse<p align=right>En ligne (ubi.com)
-<font spacing=-18>
-<font size=24 spacing=-10><p align=left>Karine Renaud<p align=right>Graphiste 
-<p align=left>Michel Gauthier<p align=right>Intégrateur Web 
-<p align=left>Karine Martel<p align=right>Conception Web
-<font spacing=-18> 
-<font size=26><p align=center>Assurance Qualité<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Sylvie Tremblay<p align=right>Responsable AQ
-<p align=left>Gabriel Dubuc<p align=right>Testeur
-<p align=left>Jean-François Giguère<p align=right>Testeur
-<p align=left>Martin Michaud<p align=right>Testeur
-<p align=left>Véronique Fortin<p align=right>Testeuse
-<p align=left>Lyne Archambault<p align=right>Testeuse
-<p align=left>Jean-Sébastien Primeau<p align=right>Testeur
-<p align=left>Jean-Sébastien Charbonneau<p align=right>Testeur
-<p align=left>Martin Hamel<p align=right>Testeur
-<p align=left>Pierre-Yves Savard<p align=right>Testeur
-<p align=left>Patrick Melanson<p align=right>Testeur
-<p align=left>Marc Thonon<p align=right>Testeur
-<p align=left>Martin Amos<p align=right>Testeur
-<p align=left>Yannick Gervais<p align=right>Testeur
-<p align=left>François Arguin<p align=right>Testeur
-<font spacing=-20>
-<font size=26><p align=center>Réseau et systèmes<font spacing=-8>
-<font size=24 spacing=-10><p align=left>Andrej Todosic<p align=right>Chef de groupe
-<p align=left>Ludwig Gamache<p align=right>Responsable des opérations
-<p align=left>Andy Mac Curdy<p align=right>Ingénieur logiciel Senior
-<p align=left>Denis Bertrand<p align=right>Architecture système
-<p align=left>Wei-Tang Huang<p align=right>Architecture système
-<p align=left>Shane Akhgar<p align=right>Architecture système Sr.
-<p align=left>Eric Garrigues<p align=right>Administrateur réseau (Europe)
-<p align=left>José Covatta<p align=right>Programmation
-<font spacing=-20>
-<font size=26><p align=center>Système de facturation<font spacing=-8>
-<font size=24 spacing=-10><p align=left>Serge Ménard<p align=right>Responsable de développement
-<p align=left>Perry Stathopoulos<p align=right>Développeur
-<p align=left>Sébastien Hinse<p align=right>Responsable BdD
-<p align=left>Stéphanie Cassie<p align=right>Responsable du test 
-<p align=left>Frank Zhang<p align=right>Développement réseau de facturation
-<p align=left>Olivier Paris<p align=right>Directeur du développement
-<font spacing=-18>
-<font size=26><p align=center>Europe<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Gregory Champoux<p align=right>Responsable de gestion de comm.
-<p align=left>Waldemar Lindemann<p align=right>Gestion de comm. (Allemagne)
-<p align=left>Ian Chambers<p align=right>Directeur du Marketing
-<p align=left>Diane Peyredieu<p align=right>Responsable en chef
-<font spacing=-18>
-<font size=26><p align=center>Amérique du Nord<font spacing=-5>
-<font size=24 spacing=-10><p align=left>John Billington<p align=right>Directeur du Marketing
-<p align=left>Ron Meiners<p align=right>Responsable de gestion de comm.
-<p align=left>Sam Copur<p align=right>Gestion de comm.
-<p align=left>Mark Goodrich<p align=right>Responsable Marketing
-<p align=left>Brenda Panagrossi<p align=right>Responsable Business
-<p align=left>Jason Rubinstein<p align=right>Responsable en chef
-<font spacing=-18>
-<font size=26><p align=center>Site Web<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Matt Johan<p align=right>Producteur
-<p align=left>Joe Toledo<p align=right>Producteur
-<p align=left>David Macachor<p align=right>Producteur
-<font size=26><p align=center>Production de la bande-annonce<font spacing=-5>
-<font size=24 spacing=-10><p align=left>David Jankowski<p align=right>Directeur
-<p align=left>Julien Milaire<p align=right>Montage
-<p align=left>Antoine Douadi<p align=right>Conception SFX
-<p align=left>Manu BachetSound<p align=right>SFX et Mix 
-<p align=left>Sylvain Brunet<p align=right>Enregistrement des voix
-<p align=left>Anne Langourieux<p align=right>Assistante de production
-<p align=left>Jean-Marc Broyer<p align=right>Producteur
-<p align=left>Karen Vernimmen<p align=right>Productrice exécutive
-<p align=right>Ubi Sound Studio (France)
-
-<font size=26><p align=center>Localisation<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Coralie Martin<p align=right>Responsable de la localisation
-<p align=left>Loïc Jacolin<p align=right>Chef de projet Localisation
-
-<font size=26 spacing=-10><p align=center>Enregistrements<font spacing=-10>
-<font size=24 spacing=-10><p align=center>Hifi-génie Productions
-<pb><font size=26 spacing=-18><p align=center>Acteurs voix<font spacing=-5>
+<font size=26 spacing=-18><p align=center>Acteurs voix<font spacing=-5>
 <font size=24 spacing=-10><p align=center>Xavier Kemmlein (France)<font spacing=-5>
 <font size=24 spacing=-10><p align=left>Bernard Bollet<p align=right>Atrus
 <p align=left>Nathalie Homs<p align=right>Yeesha
 <p align=left>Antoine Tomé<p align=right>Zandi
 <font spacing=-18>
-<font size=24><p align=center>Partnertrans. (Allemagne)<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Stephan Schlehberger<p align=right>Atrus
-<p align=left>Susanne Dobrusskin<p align=right>Yeesha
-<p align=left>Karl-Heinz Tafel<p align=right>Zandi
-<font spacing=-18>
-<font size=24><p align=center>Betafix Services, S.L. (Espagne)<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Juanjo López<p align=right>Atrus
-<p align=left>Pilar Santigosa<p align=right>Yeesha
-<p align=left>Manuel Bellido<p align=right>Zandi
-<font spacing=-18>
-<font size=24><p align=center>Orange Studio - Bologna (Italie)<font spacing=-5>
-<font size=24 spacing=-10><p align=left>Dario Oppido<p align=right>Atrus
-<p align=left>Grazia Verasani<p align=right>Yeesha
-<p align=left>Lello Lombardi<p align=right>Zandi
-<pb><font size=26><p align=center>Légal (Audio)<font spacing=-5>
+
+<pb><font size=26><p align=center>Musiciens<font spacing=-5>
+<font size=24 spacing=-10><p align=left>Eric Engerbretson<p align=right>Guitare
+<p align=left>Friends of Sironka Dance Troupe<p align=right>Choeurs
+<p align=left>Tasha Koontz<p align=right>Voix
+
+<font size=26><p align=center>Remerciements spéciaux aux premiers développeurs d'Uru<font spacing=-5>
+<font size=24 spacing=-10><p align=center>Ryan Allred, James Beattie, John M. Biggs, Susan R. Bonds, Colin Bonstead, Chris Brandkamp, Mathew C. Burrack, Gary W. Butcher, Christopher L. Clanin, Terry J. Coolidge, Mark T. Finch, Robert J. Emanuele, Peter Gage, Paul Gallagher, Robert Grace, Mike Hines, Steve Hoogendyk, Tricia (Bland) Kinder, Brian Kulig, Stephan Martiniere, Matthew B. MacLaurin, Douglas T. McBride, Steve Ogden, Christian Piccolo, Chris J. Purvis, Paul A. Querna, Nathan Reidt, Terry Schmidbauer, Bill Slease, Rod Stafford, Mark Stenersen
+
+<font size=26><p align=center>Remerciements spéciaux (suite)<font spacing=-5>
+<font size=24 spacing=-10><p align=center>Adrian Stone, William Stoneham, Brice Tebbs, Mustafa Thamer, Patti VanHeel, Eric G. Votava, Jeff Wilson, Eric R. Warman, Kyle Wilson
+
+<font size=26><p align=center>Développement Supplémentaire de Cyan<font spacing=-5>
+<font size=24 spacing=-10>Taylor Bailey, Ocala Bellows, Aaron Biegalski, Bryce J. Biggerstaff, John Brooks, Bryan Bussard, T. Elliot Cannon, Bret Carlson, Tim S. DeWolf, Eric Ellis, Scott Ellwanger, Mark Engberg/Colab, Brad Halpin, Keely Honeywell, Daniel Johnston, Gil Keppler, Brandon A. Knowles, Jeff Oswalt, Ryan B. Persch, Melinda Russel, Thom Schillinger, Micah Sheets, Lee Sheldon, Tyler J. Smith, Craig Voigt, Zachary M. Wellsandt, Maureen Wick
+
+<pb><font size=26><p align=center>Un Merci Spécial à<font spacing=-5>
+<font size=24 spacing=-10><p align=center>
+Blake Lewin
+Roger Faso
+Eric Large
+Ron Meiners
+Celia Pearce
+
+<pb><font size=26><p align=center>Légal<font spacing=-5>
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>Friends of Sironka Dance Troupe
 Certains sons et certains enregistrements vocaux sont fournis par The Friends of Sironka Dance Troupe, sous licence non-exclusive de Cyan, utilisé avec leur autorisation.
 
-<font size=24 spacing=-10>« Burn you up, Burn you down » interprété par Peter Gabriel
-Écrit par Peter Gabriel, Neil Sparkes et Karl Wallinger
-Publié par Real World Music Limited/Universal Music Limited
-Peter Gabriel apparaît avec l'aimable autorisation de Real World Records'/Geffen Records et EMI Records
-
-Didier Lord
-Directeur Général Ubi Music
-<pb><font size=26><p align=center>Légal (Outils)<font spacing=-5>
-<font spacing=-18>
-<font size=24 spacing=-10><p align=center>Bink
-Utilise Bink Video. Copyright (C) 1997-2003 par RAD Game Tools, Inc.
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>FaceGen Modeller 2.1
 Singular Inversions, Inc.
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>Artbeats Digital Film Library
 Artbeats
-<font spacing=-18>
-<font size=24 spacing=-10><p align=center>Havok
-Havok.com (tm), (c) copyright 1999-2000 Telekinesys Research Limited
-
-<img align=center resize=no blend=alpha src="xUruCreditsLegalLogos*1#0.hsm">
 
 <pb><font size=26><p align=center>Licences Open Source<font spacing=-5>
 <font spacing=-18>
-<font size=24 spacing=-10><p align=center>OpenSSL
-Copyright (c) 2000 The Apache Software Foundation. Tous droits réservés.
+<font size=24 spacing=-10><p align=center>Asio
+Copyright (c) 2003-2021 Christopher M. Kohlhoff
+https://think-async.com/Asio
+
 <font spacing=-18>
-<font size=24 spacing=-10><p align=center>Free Type
-Le projet FreeType est sous copyright (c) 1996-2000 par David Turner, Robert Wilhelm et Werner Lemberg. Tous droits réservés.
+<font size=24 spacing=-10><p align=center>EXPAT
+Copyright (c) 1998-2000 Thai Open Source Software Center Ltd et Clark Cooper
+Copyright (c) 2001-2019 Expat maintainers
+https://github.com/libexpat/libexpat
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>libcurl
+Copyright (c) 1996 - 2021, Daniel Stenberg
+https://curl.se
+
+<pb><font spacing=-18>
+<font size=24 spacing=-10><p align=center>libepoxy
+Copyright (c) 2013-2014 Intel Corporation
+https://github.com/anholt/libepoxy
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>libjpeg-turbo
+This software is based in part on the work of the Independent JPEG Group.
+Copyright (C)2009-2021 D. R. Commander. Tous droits réservés.
+Copyright (C)2015 Viktor Szathmáry. Tous droits réservés.
+https://libjpeg-turbo.org
+
+<pb><font spacing=-18>
+<font size=24 spacing=-10><p align=center>libpng
+Copyright (c) 1995-2019 The PNG Reference Library Authors.
+Copyright (c) 2018-2019 Cosmin Truta.
+Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.
+Copyright (c) 1996-1997 Andreas Dilger.
+Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.
+http://www.libpng.org/pub/png/libpng.html
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>libvpx
+Copyright (c) 2010, The WebM Project authors. Tous droits réservés.
+https://www.webmproject.org
+
+<pb><font spacing=-18>
+<font size=24 spacing=-10><p align=center>NVIDIA PhysX
+Copyright (c) 2021 NVIDIA Corporation. Tous droits réservés.
+https://github.com/NVIDIAGameWorks/PhysX
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>Ogg Vorbis
+Copyright (c) 2002, Xiph.Org Foundation
+https://xiph.org/vorbis
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>openal-soft
+https://github.com/kcat/openal-soft
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>OpenSSL
+Copyright (c) 1998-2019 The OpenSSL Project. Tous droits réservés.
+This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)
+This product includes cryptographic software written by Eric Young (eay@cryptsoft.com).
+This product includes software written by Tim  Hudson (tjh@cryptsoft.com).
+
+<font spacing=-18>
+<font size=24 spacing=-10><p align=center>Opus
+Copyright 2001-2011 Xiph.Org, Skype Limited, Octasic, Jean-Marc Valin, Timothy B. Terriberry, CSIRO, Gregory Maxwell, Mark Borgerding, Erik de Castro Lopo
+https://www.opus-codec.org
+
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>Python
-Copyright (c) 2001, 2002 Python Software Foundation. Tous droits réservés.
-<font spacing=-18>
-<font size=24 spacing=-10><p align=center>Boost
-Copyright (c) 2002 CrystalClear Software, inc. La permission d'utiliser, de copier, de distribuer et de vendre ce logiciel, quelles qu'en soient les fins, est accordée sans frais.
-<font spacing=-18>
-<pb><font size=24 spacing=-10><p align=center>OggVorbis
-Copyright (c) 2003, Xiph.Org Foundation
-<font spacing=-18>
+Copyright (c) 2021 Python Software Foundation. Tous droits réservés.
+https://www.python.org
+
+<pb><font spacing=-18>
 <font size=24 spacing=-10><p align=center>Speex
 Copyright (c) 2002-2003, Jean-Marc Vlin/Xiph.Org Foundation
+https://www.speex.org
+
 <font spacing=-18>
-<font size=24 spacing=-10><p align=center>LibJpeg
-Les versions de Libpng 1.0.7, 1 juillet 2000, jusqu'à 1.2.5, 3 octobre 2002, sont sous copyright (c) 2000-2002
-Glenn Randers-Pehrson
+<font size=24 spacing=-10><p align=center>string-theory
+Copyright (c) 2016 Michael Hansen
+https://github.com/zrax/string_theory
+
 <font spacing=-18>
-<font size=24 spacing=-10><p align=center>zLib
-zlib (c) 1995-2002 Jean-loup Gailly et Mark Adler
-]]></translation>
+<font size=24 spacing=-10><p align=center>zlib
+zlib (c) 1995-2017 Jean-loup Gailly et Mark Adler
+https://zlib.net]]></translation>
 			</element>
 		</set>
 		<set name="TextObjects">


### PR DESCRIPTION
This PR brings the French credits journal contents (previously copied from Uru:CC credits, I believe) into alignment with the MOUL Uru credits that we have in English. I welcome any feedback on any French that needs to be adjusted. I made my best guesses based on existing CC credit contents for wording on titles/roles along with a sprinkling of Google Translate. There are still a few snippets in the Licences Open Source section that are in English if anyone wants to take a crack at writing those in French. I felt highly underqualified to try those myself. ;)

This PR also fix very minor spacing abnormalities in the English credits.

Videos of the results in-game.

English:

https://user-images.githubusercontent.com/94947971/195764911-b54d0f71-199d-4b72-b0c7-311805fd855c.mp4

French:

https://user-images.githubusercontent.com/94947971/195764960-bc07ad28-6485-4106-9159-4268d8c6bd55.mp4
