### PR TITLE
Fix shading on the hydrant Cleft book in Relto

### DIFF
--- a/compiled/dat/Personal_District_psnlMYSTII.prp
+++ b/compiled/dat/Personal_District_psnlMYSTII.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:209848ad1678c89b984a9b75025a3d97f20cb16cf6338c85d5c0cb476347b515
+oid sha256:9f47cf8799ada9688c25ccf7f1eaef63cefb009c887461f13c89b66eb6216a92
 size 8591326


### PR DESCRIPTION
Still not sure why the shading is wonky on this particular book since it matches how all the other books are set up, but it's particularly bad. The easy fix is the adjust the ambient (emissive) colour of the layers slightly to make it appear brighter.

Result in-game:
![Screenshot from 2022-11-21 20-12-23](https://user-images.githubusercontent.com/241708/203220566-4ec2f448-30c5-474b-b5ef-33add390db87.png)
