### PR TITLE
Additional Cyan Trailer Cameras

### DIFF
--- a/compiled/dat/Garden_District_trailerCamPage.prp
+++ b/compiled/dat/Garden_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e079f7a6d796f34b8f243d234629938ea4865a874f7fac64c8d77f93655d0554
+size 12466218

--- a/compiled/dat/Garrison_District_trailerCamPage.prp
+++ b/compiled/dat/Garrison_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df7d6a1e9c3417f8932ca2d95b6ea8fce8316d21d9df1e6a3b3dc217e8c97b7a
+size 9291

--- a/compiled/dat/Neighborhood_District_trailerCamPage.prp
+++ b/compiled/dat/Neighborhood_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aef9edbfde6e49579bb4f3440cfce836765681e1a880a297ac24abd4436e0ab3
+size 25226584

--- a/compiled/dat/Personal_District_trailerCamPage.prp
+++ b/compiled/dat/Personal_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e12dea0a6b817b598819c0bd5ac4b33c1ca09dff671a2de03a28e44c0e104a8
+size 184280

--- a/compiled/dat/Teledahn_District_trailerCamPage.prp
+++ b/compiled/dat/Teledahn_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52b6c8f13fbfaabec0cb3d090eb4d2f467ecba26b9e27d80071eeb3994a8fa50
+size 25184835

--- a/compiled/dat/city_District_trailerCamPage.prp
+++ b/compiled/dat/city_District_trailerCamPage.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5bec7de5b83e9540979814ef5ca403e9782a6af5594af75106b6497fcb012e39
+size 164086


### PR DESCRIPTION
Files needed - https://github.com/H-uru/Plasma/pull/1270

These are camera shots that Cyan used in various trailers.
They are only triggerable by console commands.
Several ages include fake npc with no collisions, by default they are not visible and need a console command to turn on.

Console command - `Logic.TriggerResponder NameGoesHere`

**Garden** - https://www.youtube.com/watch?v=c_KI2TIO0CQ
- cam1
- camCharOn
- camCharOff

**Garrison** - https://www.youtube.com/watch?v=OFeGoOchIDs
- cam1

**Neighborhood** - https://www.youtube.com/watch?v=oj6DUZTf18w
- cam1
- cam2
- camCharOn
- camCharOff

**Personal** - https://www.youtube.com/watch?v=bF0PCqH8EiQ
- cam1

**Teledahn** - https://www.youtube.com/watch?v=LgPF3lknU2A
- cam1
- camCharOn
- camCharOff

**city** - https://www.youtube.com/watch?v=RwQfnq35PfE
_cam1b and cam2b just play the camera backwards_
- cam1
- cam1b
- cam2
- cam2b