### PR TITLE
Adjust Entry/Exit animations for Ahnonay Vogondola

### DIFF
--- a/compiled/dat/Ahnonay_District_EngineerHut.prp
+++ b/compiled/dat/Ahnonay_District_EngineerHut.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a1c33d1318cdf97a5ea9958a53bdc22b6ede0ff0ec54389bce28f89c50171e0c
-size 2846528
+oid sha256:fa563dbabfa2422c027e9f7fe7fd31fa36fa8e347e56cc4ceebd7ccf469f4389
+size 2730015

--- a/compiled/dat/Ahnonay_District_Hub.prp
+++ b/compiled/dat/Ahnonay_District_Hub.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fe620186896a51d7b737e8ab0b7ce24eda5f29d1b57d99c8e44885f3c95d6a05
-size 1955272
+oid sha256:a4ac111df7a758373914550d014ff82b0b4a1306669850472550afffde6cef1e
+size 1936831

--- a/compiled/dat/Ahnonay_District_Vortex.prp
+++ b/compiled/dat/Ahnonay_District_Vortex.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b33aaf5ec03a0e9aea58dbad6c9c5ade8cbcb6e02aad64bcca09aa2d0df2ce0f
-size 7028074
+oid sha256:d6a5c925f5d9031f2c64daf40ef2b4ba7fcb07740cff040055570d8bb563d4d4
+size 6999253


### PR DESCRIPTION
Fixed the Ahnonay Vogondola Entry and Exit animations so that they line up better than before.

This changes the entry exit seats animation and splits it into two animations, Up and Down.
I also adjusted the coordinate that the players entry and exit animation starts at.

Male:
Hut - https://www.youtube.com/watch?v=t1PcRT6uhOE
Hub - https://www.youtube.com/watch?v=_3EbQ4OtLdY
Female:
Hut - https://www.youtube.com/watch?v=QZeGAq5y7EM
Hub - https://www.youtube.com/watch?v=dthzhnggUgk

Diffs:
[EngineerHut.txt](https://github.com/H-uru/moul-assets/files/10248514/EngineerHut.txt)
[Hub.txt](https://github.com/H-uru/moul-assets/files/10248515/Hub.txt)
[Vortex.txt](https://github.com/H-uru/moul-assets/files/10248513/Vortex.txt)