### PR TITLE
Add *.sub line to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,7 @@
 *.prp filter=lfs diff=lfs merge=lfs -text
 *.psd filter=lfs diff=lfs merge=lfs -text
 *.pxf filter=lfs diff=lfs merge=lfs -text
+*.sub text diff eol=lf
 *.tga filter=lfs diff=lfs merge=lfs -text
 *.tif filter=lfs diff=lfs merge=lfs -text
 *.ttf filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Not sure how useful this is, but I noticed the new *.sub file type didn't have a line in the .gitattributes. As far as I'm concerned, it should be treated the same as other text files, like *.loc files.