### PR TITLE
Update Serene.loc for new journal contents

### DIFF
--- a/compiled/dat/Serene.loc
+++ b/compiled/dat/Serene.loc
@@ -1,497 +1,226 @@
 <?xml version="1.0" encoding="utf-8"?>
 <localizations>
-	<age name="Serene">
-		<set name="Journals">
-			<element name="thejournal_DRAW">
-				<translation language="English"><![CDATA[<margin right=30 left=50 top=30>
-<font size=24 face=Courier color=221166><pb><p align=center>
+    <age name="Serene">
+        <set name="Journals">
+            <element name="thejournal_DRAW">
+                <translation language="English"><![CDATA[<margin right=30 left=50 top=30>
+<font size=18 face=Michelle color=221166><pb><p align=left>June 9th
+I took a small makeshift boat, and decided to head for a spot in the wall of the cavern. I found a small cave where I landed and wandered around, lost, for a day or two, when I stumbled upon a bigger cave with a walkway. As I made my way down it, when I got to a certain point, a gate came crashing down and I have not been able to get it opened back up. This walkway led to the Atrium of Neolbah. Fortunately, there was a Nexus linking pedestal there with a book going to the Nexus and, by using it, I was able to have a link to this place included in my KI.
 
 
+July 5th
+Finally got the what I call "Maintenance" door open! Then had yet more D'ni tech to face... sigh...
 
-The
-Devokan
-Story
+Good news is that I got it working... er... um... in a "This Is Really Jury-Rigged" sort of way, heh.
 
-Book II
+Problem is, I had to reset the door code... and if you enter the wrong one, the power resets on it! Just can't figure it out...
 
-<font size=16 face=Courier>February to
-May 2010
+Ah well.
 
-<pb>
+I did remember to leave a note to Dot on her desk down there with the code. So she and any other visitor should be okay.
 
-<pb><font size=20 face=Atrus color=000000><p align=left>
-I have compiled this chronological account from journal entries and notes written by individuals at the time. The events follow on from those chronicled by Dot Macchi in The Devokan Story: Book I, although I have repeated a few entries here in order to give some context to what follows.
+Now I've got to get back to the surface and the other project that I'm working on...
 
-My aim is to communicate the urgency and the reasoning behind my actions and research. 
+Now where did I leave my coffee cup???
 
-Quinquifid Oddenfen
-The Devokan Trust
 
-<pb><font size=11 face=Courier color=221166>=== Places === 
-Devokan -- the island on my original home world now destroyed by its own sun
+August 18th
+Linked back in to Neolbah today. Found one of the doors acting up. Swift kick or two seemed to fix it. :shrug:
 
-Winterfell -- an area in another world where Dot Macchi set up a base
+I wandered over to the door that I've not had time to get working yet. I thought I could hear something. I pressed my ear against the door. Was that a dripping noise I heard? Hard to tell with the water splashing in the fountain and the noise from the imager going on.
 
-Areas in the spheres' source world:
-Waysmeet -- the tree village transferred to this new world by the mysterious spheres (see Book I)
+I was walking over to my table when Dot linked in. Scared me to death! All these years and I'm still not used to someone suddenly popping into existence in front of me like that! Gah!
 
-Devokan Touchstone -- the island I attempted to transfer across, a twin of the original Devokan
+The look on Dot's face was very clear to me: "I'm really ticked off right now and want to be alone!" However, the look changed quickly into a smile and a wave of hello when she saw me.
 
-Tallis -- Mr Mahogany's home island
+Right! I'm glad it wasn't ME that had ticked her off so bad! Whew!
 
-Skysong -- an uninhabited island over which I set up a sky laboratory and that I intended for my home
+I could tell she wanted to be alone though, and I needed to get going anyways. I've got a new area that I've been looking into that's in the Great Shaft. So giving excuses, and waving goodbye, I quickly used my Relto book to leave. I knew I'd be back later.
 
-Curiosity -- the island that became Paislee Myrtle's home
 
-Deepwater -- an ancient island of ritual and mystery; at its heart is a temple housing a "caged" sphere, hence the speculation that this is the source of the spheres' power
 
-Nalands -- Nalates' island base
+August 23rd
+Today I rushed back to Neolbah to see if Dot was there. I wanted to tell her what I and my friend Moe found up in the Great Shaft!
 
+Moe is from Down Under, in Cairns, Australia. I met him a ways back while playing an online game. We've become fast friends and I had told him all about the Cavern and the D'ni.
 
+Moe was fascinated with what I had described to him. His wife Meg (short for Megumi) and he flew to the States to visit me and Tracey. Of course with him visiting, I just could not resist dragging him down here!
 
-<pb>:::  F E B R U A R Y  :::
+To make a long story short (and by the way, Moe stands at about 6 foot 8 inches... I forgot he'd need a hard hat. He spent a lot of time yelling "OW!" down here), I decided to take Moe down the Great Shaft.
 
-=== February 5 === 
-I linked back to Devokan to check how things were going with preparations for the final evacuation and to tell the others of my plans: the laboratory I set up in the new world, and some of the equipment I have been able to bring across.
+The look of wonder on his face was worth every gripe from him about his sore feet, which he promptly forgot about when he looked down the shaft from the top! Heh.
 
-My hope is to tap into the growing strength of the sphere above the standing stones that have reappeared in Devokan. 
+We made our way down using the series of elevators and walking paths until we got about half way. I'd heard there was a Rest Room right about here (there are several, but this one took some getting to).
 
-It will be a risk -- I don't completely understand the underlying mechanisms -- but given the choice between that and the complete loss of that wonderful island, one worth taking.
+Once in the Rest Room, I pointed, while bent over breathing hard (I've GOT to lose some weight!). Moe looked over and said, "What? It's just another bloody room that... Look... the... that door back there is open!"
 
-So I am going to stay in the new world, monitoring the instruments, trying to control and focus whatever it was that enabled this transport of living and non-living matter, and that was growing strongly by the hour. 
+Still catching my breath, I stood upright and nodded my head. Yep, the door was open on this one!
 
-I shook hands with each of them, wished them luck (as they did me), and returned to the spheres' source world.
+We moved in and to my astonishment, it looked like some sort of pub or bar! There was a place for people to sit, and even what looked like a small kitchen!
 
+I could tell Moe was getting aggravated with me, as I kept smacking his huge hands yelling, "Touch nothing!"
 
-<pb>=== February 7 ===
+Further investigation revealed what looked like living quarters. That's when I found a book! That is also when Moe got another smack to his hand. I remember him looking at me confused saying "Look, mate, it's just a book! How is touching it going to--"
 
-Devokan is no more.
+He broke off as I was waving my Relto book under his nose. "Just a book?" I looked at him with raised eyebrows. "So what happens if you open it up and touch it? Nothing? Or maybe a sudden lurching feeling, and existing... where? A tropical island? A dark pit? A place whose atmosphere is poison to us? Do you want to find out the hard way?"
 
+Moe grinned sheepishly at me (well, as sheepish as a man his size can look), and shrugged. "Sorry, mate. I'm still new to all this."
 
-As I watched from my temporary lab 
-in the spheres' source world 
-over the last few hours, one by one 
-the monitors went blank.
+I held up my finger and drew a pen out of my pocket, one that I had been using to take notes. I gently lifted the cover of the book over, and saw simply D'ni writing. No linking panel.
 
+"It's safe," I told Moe. "But it's a good find! It might tell us about this place."
 
-First Selenitica's satellite mine, 
+"You can read that chicken scratch?" Moe asked me with eyebrows raised (he has a big forehead, so this is really a sight to see, heh).
 
-then Selenitica itself, 
+"No," I replied. "But I know people that can."
 
-then the Lost Pages sphere,
+I pulled a large bag from my backpack and slipped the book into it. Then placed it back in my pack.
 
-then the beautiful island of Devokan.
+It was time to go then. I knew I would be back, but for now I had other places to take Moe.
 
+I left Moe in the good hands of Steve at the Ferry Terminal in Ae'gura. I wanted to get back to Neolbah and tell Dot what I had found. When I left them, they were busy discussing Australian beer, or "Aussie Beer" as Moe calls it.
 
+I shook my head. Here he was 3 miles down underground in the ruins of a 10,000 year old civilization, and they were going to discuss beer...
 
-I weep. 
+Dot wasn't in Neolbah. Felt like I had just missed her. Sighing, I was about to link out when I thought I heard something. It was from the elevator shaft. The elevator itself was not present.
 
+I walked over and called it up to me, and rode it down to the basement. Walking to the end of the tunnel, I didn't see anyone.
 
-<pb>=== February 10 ===
+I stared at the two valves that are down there. I keep thinking they do more than just maybe shut off the fountain. That's when my eye caught the book lying on a crate!
 
-Two solid days, sitting there in the laboratory, watching, adjusting a slider here, a knob there; hoping against hope that the conjectures and calculations about the spheres might have some substance to them, that my efforts might not be in vain.
+Who in the world left this here? When did this happen? I need to get with Dot.
 
-Utterly exhausted, I emerged from the lab this morning, and linked.
 
-The island was transformed! 
 
-Somehow, the land had been remoulded into the hills and valleys of our lost Devokan. 
+October 30th
+Head hurts... pounding really. All the linking I've done, and I've never had a headache like this before... did I link?
 
-As I watched, rocks, streams, plants seemed to form out of the atmosphere -- a crystalline shimmering in the air, and then the wood, the waterfalls, the sounds,...
+I don't know where I'm at. Worse. My Relto book isn't on me either.
 
-I walked in a daze, looking around me in awe. It all fitted -- the geology, the ecology, all matched.
+Thinking... I was in Eder Tomahn, examining one of the elevator levers. They're stuck, but I think I can free one up.
 
-The island has come home.
+I left and linked to Neolbah where I had left some of my tools. I don't remember what happened next. I remember being IN Neolbah, but... the next memory is me opening my eyes here. Wherever 'here' is.
 
+I can't place it. I've never seen this place...
 
-<pb>=== February 16 === 
-I have been here in the spheres' source world for nearly two weeks now. Most of that time has been spent monitoring the equipment, checking, adjusting.
+But someone has been here, I think...
 
-I am feeling lost, bereft. This place is both Devokan and not-Devokan. Where is my home? Where do I belong?
+Yes. I think I need to explore... maybe I can learn something...
 
-Perhaps I have been pushing myself too hard. Must link back to Winterfell. Talk to someone.
 
+November 17th
+You know, you'd think I'd have learned after all these years of exploring the Cavern here underground, and whole alternate worlds, to NOT touch something when I don't know what it is!
 
-=== February 17 === 
-Where is everyone? I link back to the Keep building in Winterfell, and there is no one here!
+My trip to this place called "Nocturne" was very interesting (if unexpected). I saw many new things before Quin found me wandering around.
 
-Fortunately, Mr Fax Palladin contacted me soon after I linked in. The ensuing conversation was enlightening and helpful. 
+I took a couple of weeks and took in the sights until Quin brought me back home. But that's another story.
 
-It seems that in the same weekend that Devokan was destroyed (and Mr Palladin was there to observe it), access to the Uru cavern was regained. That might explain why no one is here in Winterfell. Miss Dot was one of the exiles from the D'ni city -- she would be eager to rejoin her colleagues there.  
+During the time I was there with Quin, he asked me about Descriptive Books and Linking Books. Their differences, and purposes.
 
+I took him to my Relto and showed him some of the Descriptive Books that I had found, plus those that I had created while dabbling in the Art.
 
-<pb>=== February 19 === 
-I have taken Mr Palladin's advice. I have gone to the cavern.
+Quin was quite insistent about visiting some of these places (well, as "insistent" as Quin gets, which amounts to a single raised eyebrow and a "I would very much like to see this place, Mr. Legate.").
 
-The initial dream? vision? as I first linked in was most poignant: Destruction has indeed come to us at Devokan...
+So I took him to Zephyr Cove, Camp Bravo and ended with Serene.
 
-Must find a way, make a home...
+Serene seemed to draw a strange expression across Quin's face. I've seen wonder, awe and even surprise on people's faces when they visit Serene, but never an expression of... puzzlement. Something about Serene seemed to puzzle Quin. He spent a lot of time walking around, looking and exploring every inch of it.
 
+Later, back at my Relto, Quin asked if he might take a look at my Descriptive Book for Serene. I handed it over to him, and caught the faintest look of delight on his face. If I had blinked, I would have missed it.
 
-=== February 22 === 
-Keeping myself busy with exploring, experimenting, writing.  
+I asked him to look after it, making him understand that if it were harmed or damaged that Serene would be gone forever.
 
-It all helps a little, but the black mood upon me is strong. 
+Nodding in understanding, he left and I headed back home to my family. Thanksgiving is coming up and I've got turkeys to cook!
 
 
-=== February 25 === 
-A chance encounter with Miss Dot's friend Ametist in the Uru cavern. She suggested I spend some time alone, taking the Journey, the one that starts in the desert.
 
-Picked up some supplies from the Keep (enough for a fortnight) and left a note for Miss Dot and Miss Paislee -- they might be getting concerned about me. Not seen them since the 5th of February. 
+November 26th
+Quiet rage.
 
+Disbelief.
 
-<pb>::: M A R C H :::
+Shock.
 
-=== March 1 === 
-Received a KI mail from Miss Dot, requesting a meeting. She and others would like to visit spheres' source world, possibly to develop a base there. 
+These are some of the things I'm feeling as I sit here on a rock, looking out over the ocean here at Deepwater.
 
-Sent KI mail back suggesting that we met up in Eder Gira. 
+Serene. It's gone. At least the Serene that I created a link to is gone. What's there now is... well, not Serene, and yet it is Serene.
 
-Mood is beginning to lift at last.
+I should have seen this coming. I should have been able to keep it from happening...
 
+Several days ago, I decided to link to Serene. The snow and wind always put me in the holiday mood, and with Thanksgiving approaching, it felt like it was just the ticket.
 
-=== March 5 === 
-As arranged, Miss Dot arrived at Eder Gira and, after helping me with those troublesome fish baskets, we linked back to my Relto and from thence to the Keep at Winterfell.
+To my shock and horror, my linking book was not working. The linking panel no longer showed Serene, but instead was a grey swirl and smoke. The link had been severed. How?
 
-There I explained how to link to the spheres' source world, and potential problems and difficulties. Dot was not to be persuaded otherwise: she was determined to visit this other world -- she said how some friends of hers were about to lose their own home base in a world called There, and how she hoped there might be a possibility of finding a place for them in this new world.
+I immediately thought of Quin and the fact that I had given him the Descriptive Book to Serene for study. My thoughts turned to concern for his safety. Had something happened to him while he had the book?
 
-So we linked. For once, the journey went remarkably smoothly. Things seemed much the same as I had left them. My laboratory in the sky was still intact, though the machinery sounded as though it could do with a few more squirts of oil.
+I started linking to all the places I could think of where he might be. When I got to Neolbah, I found a note from Dot sitting on her desk.
 
-Dot was most interested in how the small sphere was held in place. I based that machine on a more primitive kind I found in what I assume is a temple of some description, on the island I have called Deepwater. (Though I say 'more primitive', if I am honest with myself, the magnitude of the flux measurements I took in Deepwater astonished me: that 'primitive' mechanism is able to cope with forces far greater than I would like to test in my laboratory.)
+When I read that note, my feelings of concern for Quin vanished. Instead, I went ice cold with rage.
 
-I warned her not to get too close to the sphere: it hovers over what warrior Nalates would call a space-time 'wormhole' -- an ugly term ill-suited to the depth of beauty and majesty that can be glimpsed within it.
+I linked to Shell 415 in Ahra Pahts where I found D'Lanor and Ametist working hard. As I approached them, I guess they could tell how upset I was. D'Lanor's face went blank except for the quick blinking of his eyes. Ametist had started to smile at me, but the smile shattered and I don't think I've seen her go that pale before.
 
-We then descended to the island of Skysong and from there to the transported island of Devokan Touchstone.
+I stopped in front of them and asked quietly, "Where's Quin?"
 
-There, to my shock and Dot's immense surprise, we were greeted by a man. She had met Mr Mat Mahogany before; the last time in Selenitica, when it was about to be burned up by its sun. He was there in his spaceship and helped with the evacuation. 
+Ametist's eyes got even wider at the tone of my voice. "I'm not sure, Andy," she replied. She then pointed towards a hedge, "But he was here earlier. He left that linking book to Serene over there."
 
-The subsequent discussion we had, which lasted into the small hours of the morning, is likely to have momentous consequences in the days to come.
+I walked over to the book and picked it up. Opening it showed a working linking panel to Serene... but yet, not quite Serene.
 
-Mr Mahogany took us to his home island of Tallis in the spheres' source world -- many miles by sea, though a few seconds by his teleportation device. 
+Turning towards D'Lanor and Ametist, my hand hovered over the linking panel. My eyes met theirs. D'Lanor's mouth hardened to a straight line, and his head gave a slight nod.
 
-We were shocked to recognise that it had the familiar terrain of Devokan, though the buildings were alien. Yes, in this new world there are two islands with the same terrain as Devokan. Mr Mahogany was as puzzled as we were.
+My hand slapped down onto the linking panel and I faded away from Shell 415.
 
+I'd seen understanding in D'Lanor's eyes. He knew Quin had done something unforgivable.
 
-=== March 9 === 
-Because the instruments I have in place in the laboratory over the island I have called Skysong, next to the transported Devokan Touchstone, were indicating a further build-up of flux in the spheres, I decided to investigate further.
+Quin had destroyed an Age. 
 
-I linked back to the Keep at Winterfell to pick up some more equipment.
+------------------------------
+It was Serene, but not Serene.
 
-Just as I was placing the last device into its heavy-duty travelcase, Miss Paislee turned up, full of curiosity about what was happening. She asked if she may return with me -- for she had been struck by that world's eerie beauty when she had inadvertently been linked there before.
+I stood there, I don't know how long. Numb, but not from the cold. Numb with shock, anger and, strangely, wonder all at the same time.
 
-I was initially reluctant, because of the potential instability. However, she was most insistent, and so I agreed.
+The path was made of different stone. There were more trees. Even the snow looked different to my eyes.
 
-We linked, and at once Miss Paislee saw the cause of my unease: the two islands sharing the same terrain. What is more, Tallis and Devokan Touchstone are now side by side -- something I had not expected! I have heard of parallel universes, of course, but seeing this happen in reality was quite startling.
+Finally I slowly turned around to the Nexus book stand. It was still there, and even looked the same. An Age Anchor? I'd never thought about it. But Anchor or not, the linking book to the Nexus was gone.
 
-I am hoping that Mr Mahogany might be able to shed some light on this mysterious occurrence.
+I moved slowly down the path, and saw a temple. There was red light coming from it. I stopped again.
 
+I knew that design. I'd seen it in pictures. It was from some of the places Quin had been.
 
-<pb>=== March 14 === 
-Today Miss Dot and her friends said goodbye to yet another world in which they had made homes during the exile from the Cavern. I found her account of the event quite moving:
-------
-An hour before the world known as 'There' was due to vanish, I linked in to Uru Island where many from The Meeting Place hood and other friends had gathered.
+Quin. My hands curled into fists on their own. How could he do this? How could he just disregard everything I'd said about Descriptive Books?
 
-I left after a little while, to spend time alone in Eder Devokan, the mountain valley in Aurora Island that sengel, Ivy and I had purchased deeds for in early May 2008. Slowly, I walked around the neighbourhood, saying a personal farewell to Eder Devokan, and to each of the areas so carefully developed and built by people like Paislee, Ilf, Lareh, blutec, Ivy, sengel, Stejovis, as well as remembering those by JimQ and Nynaveve.
+I went no further, but quickly linked back to my Relto. My feet went out from under me and I sat down hard on the ground. I began to shake with rage. The temper I'd gotten from my mother, that ugly beast that I always keep chained up and caged. It raged against the bars of its cage. Howling to get out. It would not stay locked up.
 
-As midnight approached, I climbed to the top of sengel's waterfall to watch and wait. A few seconds after taking one last photograph, I blacked out. Destruction had come.
+So be it. I was alone. I let it out.
 
-I awoke a moment later in Relto. I checked my KI, and saw one by one the names of friends and neighbours appear on the list. They too were linking to their Reltos. I used the hood book and waited there, by the fountain. And so we gathered -- an exodus from the world many had made their home since the first exile from the Cavern, together with friends who had known no other. It was an emotional time for many.
-------
+Some time later, I came to my senses, lying on my side, breathing hard and feeling exhausted. My vision was blurry from tears. I quickly sat up and wiped them from my eyes.
 
-After this, Miss Dot had linked back to the Keep, but Miss Paislee and I had not returned from our travels. So once again -- this time on her own -- she followed my earlier instructions and made it back to the spheres' source world. 
+The beast was back in its cage. Locked up where it would stay. Still seething, but under control now.
 
-We discussed what should be done next. Miss Paislee spoke of her intention to remain in this world, to maybe settle here. I will continue with my research over Skysong. Mr Mahogany has made us all most welcome here. 
+I got on my feet and walked to my Relto hut.
 
+It was time to confront Quin.
 
-=== March 21 === 
-Miss Paislee sent me the most charming note:
-------
-Looking out over Curiosity toward Devokan Touchstone this morning,  I finally feel I'm home in this new land. Ships at anchor offshore promise adventure and new friendships. The strange familiarity of my new surroundings brings comfort and ease.
+------------------------------------------------
 
-Busying myself with settling in here has soothed the loss of our beloved Devokan. Life is strange... The old saying about the closing of one door opening another has come true for us.
+I found Quin in Neolbah. He was in Dot's office, with Dot. I could see the concern on her face, yet Quin's expression was one of confusion.
 
-This house on the hill is for all to share -- a place enjoy the sweet music of this new world, to remember old joys and shared experiences of the past, and to savor the company of friends, both new and old.
+I began to speak, addressing Quin. I kept my voice low, steady but ice cold.
 
-Only meant to write a quick line! Must take my leave to lay a fire in the fireplace and prepare for company...
+I dressed Quin down. Describing how irresponsible his actions had been. How he'd had no right to tamper with an Age that was not of his creation. That never again would I trust him with anything so precious.
 
-I wonder what the future holds?
-----
+Quin's eyes widened only briefly, but his expression quickly turned hard. Instead of regret, remorse, or guilt, he instead looked at me with his own anger, and what looked like disgust.
 
+When I was done speaking, he simply linked out.
 
-=== March 21 === 
-I have copied this entry from Mr Mahogany's journal. 
------- 
-I have been looking everywhere I can, but still I cannot find my old diary. I had it before the light and the planet shook, and I lost my mind. All that remains of it was one entry I found on the floor, torn from my book. 
+The office remained quiet for a few minutes, then Dot spoke.
 
-The gentleman called Quin has given me a new  book, as a gift to make my record. And so I write today as though it was the first day, the new beginning to my life.
+"Andy, I know how angry you must be. Please realize that Quin in many ways can be like a child. A child who has lost a whole world and saw a way to bring at least part of it back. Can you understand that?"
 
-Today... I have only just found my senses, I believed it all to be a dream, and that each day that passed, I would rise up, and see old familiar ground. But as each day passed, that dream faded, and so I have come to realise, finally, that from now on, this is what is, and all that was has been. It is no more.
+I looked over at Dot. "Yes, I can understand it. You are right in that he's like a child. And like a child, who wishes so hard to bring something back, he had no thought of the fact he was going to cause the exact same loss on me. Maybe you can explain that to him sometime. That while he may have brought something he lost back, he's inflicted the exact same loss that he suffered upon me."
 
-I notice, it is different here. Not just because of the way that the islands are now merged and mixed up, but in other ways too.
+I shook my head sadly. "Sorry, Dot. I've got to be alone for a while."
 
-I feel a sort of tingling in the air.
-
-There is a metal taste in my mouth, and the smell of the sea is very strong. The fish have left me too, so I have to go to other places.
-
-I walked today, over the newly formed islands to explore. This was where I noticed the harsh flavours were more obvious.
-
-The identical island named 'Touchstone' is possibly the most electrifying. I can feel the hairs on my arm rise up and my pulse quicken. As though I can feel the very insides of the planet want to pull me over.
-
-It's different and I think it will not be the same again.
-------
-
-
-=== March 28 === 
-Over the past week I have been systematically pacing the islands in a grid pattern, using a portable flux monitor to map out readings in each area.
-
-While I would not put it quite so poetically as Mr Mahogany, I can confirm that there is indeed a build-up of activity on the island to the west of Tallis, the 'new' island of Devokan Touchstone that we suspect is the one that the spheres transferred across.
-
-The flux is particularly strong towards the southeast, roughly where Miss Dot's keep was in the old world.
-
-
-<pb>=== March 31 === 
-Miss Paislee showed me a poem she has composed:
-
-------
-New Land
-
-Tonight there is a glow about the land.
-Shimmery glimmers evoke gentle thoughts.
-Memories of times past, friends recalled.
-
-Earthy scents waft from the soil
-As fireflies rise from the soft new grass
-To brush against our outstretched arms.
-
-Dusk bestows its gentle touch upon us
-Envelops us in its soothing silence.
-A quiet celebration of life's goodness.
-
-Peace to you, friends, in this new land.
-------
-
-It seems she has found a home here. If only I could feel the same...
-
-
-<pb>::: A P R I L :::
-
-=== April 2 === 
-Miss Paislee and Mr Mahogany are busy building and landscaping. Miss Dot drops by occasionally to see progress. My work continues. I keep myself to myself here in my lab. 
-
-
-=== April 4 === 
-I have heard from warrior Nalates:
-------
-I am still having nightmares of the invaders. So, I did some searching using the technology I took from my destroyed home and what I learned studying the spheres and talking with you. I did not find the invaders. I feel better. Not yet at peace.
-
-Exciting. I did find new worlds. One had an island I liked. I decided to "appropriate" it. Using the tech I have I moved it to the world we moved most of Devokan to. Unsure if I could pull this off, I planned to move it out to the west of Devokan in open water. It's still not completely stable. It phases in and out of existence. But, it is mostly there.
-
-I remember my surprise at finding an old D'ni world in my search. It is mostly in ruins, totally uninhabited. My search gear would let me find single shrew on the planet. I'm certain no one is there. I found an interesting building. I did not recognize it as D'ni. But, there are traces of D'ni technology, records, various guild symbols... obviously some central meeting place for the old D'ni guilds. Considering the guild hall and palace in Ae'gura this must be some kind of outpost. I am so intrigued.
-
-I decided I needed a base of operations and place to build tools to control the spheres and a power station. I'm still not sure how the spheres we have encountered are energized. As long as they are not completely in my control I have doubts about using the technology.
-
-I've started building on the island... mine now I guess. I shipped and received the barrels from the old D'ni guild hall from Earth to here. I've started building storage for them in the new basement. I've got computer equipment set up to study the spheres and see if I can stabilize the island. Once I have my stuff working I'll try to pull the ancient building in. With any luck I can reach back and pull the building from a much earlier time when the building was in better shape. I suspect I better be careful. If I break it in an earlier time I might destroy the building in following times too. Then I might not be able to retrieve it.
-------
-
-
-=== April 9 === 
-The flux around some of the islands continues to increase.  
-
-As far as I can tell, there seem to be two separate processes at work -- one of which is causing quite drastic changes to the island of Devokan Touchstone. I met Mr Mahogany earlier today, and he showed me what was going on. He is somewhat concerned.
-
-Tying it in with the systematic flux readings I have been taking over the last week or so, it seems that there is a direct link between flux intensity and amount of change in terrain. Devokan Touchstone now has a deep crack running its length, and parts of the terrain are being pushed (or pulled?) upwards. One example of the latter is in the SW corner, where readings were particularly high.
-
-The other process my instruments have picked up (it has quite a different 'signature' to the other) -- I assume that that is occasioned by the smaller spheres over the ocean to the south of Nalates' island. They look an interesting development; I have not seen the spheres emit 'sparks' before. I must ask Nalates what she thinks is going on there.
-
-
-=== April 11 === 
-Nalates has responded:
-------
-I'm not sure how related some of these things are. I have one captive sphere and 4 or 5 semi-controlled spheres on my island and south of my islands. I have no idea if they are having an effect on Touchstone. If you see a connection, let me know.
-
-The test sphere, the one I call captive, is in the building I'm putting up on my island. You can see it best from the third floor. The computer controls are in the basement right now. I adapted the computers I use to monitor the phasing in and out of the islands to control the spheres until I can get more equipment.
-
-I have the "elevators" working. Traveling forward I brought back some technology and used it to make getting around easier.
-
-The other spheres are being used to capture the old D'ni building I found. You'll find those to the south of my island in what was open water. Some of the terrain is being pulled across now. I am trying to slow the process until I can learn more about the spheres... or at least the process they use. The new terrain should be reasonably stable, for now.
-
-One of the things I did notice is changing the energy source has shifted some of the effects in the sphere's process into the visible spectrum.
-------
-
-
-=== April 12 === 
-Miss Paislee reported a dream she had:
-------
-Last night I had a dream.  It's not often I remember my dreams, but this one was a revelation from which I awakened trembling....
-
-In my dream, I was wandering about these worlds -- free to travel where I chose. While crossing the mountain toward the pods, I stumbled in my dream. I must have hit my brow on a stone for I remember nothing until I dreamed.
-
-In my dream I opened my eyes and beheld a wierd and wonderful sight! Spun out before me as far as my eyes could see was a giant weaving of string...like the web of a giant spider. But 'twas no simple circular web I beheld, but a weaving so cunning, so cleverly made of colored strands interlaced and folded back upon themselves that I could not comprehend it all.
-
-The earth on which I stood was not solid earth. I could see through to the bones of the world... I could see through the mountain to Devokan Touchstone. In a panic I gazed upward and saw a giant net canopy enveloping everthing. Stunned... I realized I must be dreaming yet I dared not take a single step for fear I would fall through....
-
-My senses returned and my forehead throbbed. Gingerly I touched my temple to see how badly I was hurt and caught a glimpse of my insubstantial hand! For not only was this world made of a giant's Cat's Cradle, but my hand was as well!
-
-I don't remember waking from my dream, if it was a dream. But this morning I took a spade to the mushroom patch and dug a deep hole, thinking perhaps I could find the strings that bound the world in my vision.
-
-The only thing I found was earth. Still... I do wonder if this world is all that it seems.
-
-I am very uneasy because this morning I noticed a small bruise on my temple. Was it a dream... or real?
-------
-
-
-=== April 14 === 
-I showed Miss Dot the cracks that have appeared in Devokan Touchstone -- they are deep, filled with water, criss-crossing the island. They are wider and more numerous than before; I cannot explain what is happening.
-
-Fortunately Tallis seems unaffected, and nor is Curiosity, the island to the north where Miss Paislee is based.
-
-It might be as well not to link directly to Devokan Touchstone at present. On the occasions I have tried, I have been struck by a kind of paralysis, unable to walk one step (I am able to link away from the place).
-
-
-=== April 16 === 
-Miss Dot met up with Miss Paislee on Wednesday. They linked to Devokan Touchstone together -- and experienced the same strange inability to move.
-
-What was even more alarming to them was that most of the island was now submerged -- the cracks had opened up and merged. Yet in two places, the land had risen sharply upwards, some 50-60 metres.
-
-
-=== April 20 === 
-Miss Dot sent me a note:
-------
-I have just re-visited Devokan Touchstone.
-
-An ugly red glow blights what remains of the land.
-
-The sea, no longer calm, displays a turbulence driven from below. Debris from destroyed walled gardens swirls around, caught fast in whirlpools.
-
-One of the elevated regions seems to be trying to twist itself free of the spiky grasp of this festering landscape.
-------
-I am very, very angry. I meant this to be a new home for us all.
-
-
-=== April 21 === 
-What might be behind what is happening?
-
-Mr Mahogany, in an earlier discussion I had with him, suggested that the two instances of Devokan (i.e. Touchstone and Tallis) in the same world, and in such close proximity, might be caused by some error in the transfer process (which involved a temporary space-time wormhole between parallel worlds); one key parameter out by a factor of 10^-12 would be sufficient to disturb the meshing of the transferred Devokan (Touchstone) with the original island (Tallis) in the destination world.
-
-Perhaps this turbulence is part of a restoration process, as a single instance is re-established.
-
-On the other hand, perhaps it has nothing to do with the transfer process -- a more worrying scenario in that we do not know whether the turbulence and destruction might spread.
-
-There may be parallels here with what Nalates is doing. Though if it is the former, a restoration process, I would have expected a better match between the 'signatures' of the spheres employed in her experiment and the flux over Devokan Touchstone. 
-
-On a more intuitive level, the transfer process instigated by the spheres, though disturbing in some ways, was beautiful -- mathematically, aesthetically, harmoniously; this turbulence is chaotic, ugly, discordant.
-
-So on balance, I would say we are faced with the latter scenario. In which case, how might we contain and constrain this dis-ease of the land? Might we be able to pool our resources, Nalates, Mr Mahogany, and I?
-
-
-=== April 26 === 
-While the turbulence is still there, and still has the potential to spread and poison its surroundings, it seems there is a way of working around it, of nullifying its effect and influence. Sorting out this will require close teamwork.
-
-Mr Mahogany has been able to stabilise some new land to the south of his large ship, away from the currently blighted areas. Through use of his technology (closely linked to that of the spheres, it seems) he has transferred Miss Paislee's island of Curiosity complete with buildings and fauna.
-
-Two further regions have been prepared to the east of Curiosity. The plan is to transfer Waysmeet and Deepwater here. While we have managed to build a replica of the terrain of Deepwater, the buildings and landscape details are proving a little more problematic. 
-
-The set up is this: Mr Mahogany and I have added copies of the spheres that were involved in the original transfer to this new world to the existing Waysmeet and Deepwater. Then, copies of Nalates' adaptation to make a 'receiving' sphere are placed in the new regions.
-
-
-=== April 28 ===
-I need to try some further experiments on the crystals, but that equipment is still in Winterfell. Unfortunately the only building we have there now is Miss Dot's cottage. 
-
-I left a note for her on the kitchen table:
-------
-Shorah, Miss Dot
-
-You might have noticed that I have taken the crystal distillation experiment out of its storage case. My apologies for the short notice, but events in the spheres' source world seem to call for drastic action.
-
-Of course, with the disappearance of the Keep, I have needed to find alternative accommodation for the furnace. I have therefore installed it in your cottage. One could see it as an alternative method of heating -- it might also prove efficacious in driving out the damp.
-
-Your friend -- Quinquifid
-------
-
-
-=== April 29 ===
-A report from Nalates:
-------
-I'm lagging in writing to my journal. Time to get my feelings and thoughts down. 
-
-Seems I set my islands far enough west of Devokan that I'm going to bed as Dot, Mat, and Paislee are getting up. And Quin... does he even have a schedule? I hear he has taken over Dot's living room with his stinky crystal tests. Note to self: STAY AWAY.... Peweee. Maybe I should make some land available to him. Big note to self: Set up weather station and determine prevailing winds, FIRST.
-
-I miss friends. I need to travel to see them. My good friend has joined a group I have mixed feeling about. She is now high up in their organization and quit influential. She is a mentor and protector for me when I travel there. Just wearing the sign of her house is usually enough. Otherwise, it is too dangerous. My fighting skills are no longer a match for the warriors constantly involved in conflict. However, I look forward to seeing her and as a team we are still pretty bad.
-
-Travel has problems... my island is still not stable. It seems to drift in and out of the dimension we moved Devokan to. I've updated my control software twice and still have not been able to stop the drift. I can only hope for about 24 hours of stability then strange things start to happen. All I can do for now is pull things back once I notice there is a problem, which I can't when I'm away traveling. I have older computers I might be able to upgrade with newer software... maybe a dedicated control device could do more... well... when I have time.
-
-I see the ships to the east have sailed. It was nice looking out and seeing them. Which reminds me. I have to get the roof finished on the new building before the rains come... does it rain here? Actually, I have not seen rain here... yet. Hmmmm...
-
-I see swans are back. None of them seem to remember me. A couple have started nesting on my island. Others are in Devokan. I wonder where the spheres moved them when I was moving animals... they seem to have migrated in. And squee... I haven't seen them in forever. The food I put out disappears. I guess I could set traps, not that any trap would hold a squee, but if it is some new critter I would catch it.
-
-Mat and Quin seem to be playing musical islands. I see more spheres appearing. I think Mat and Quin are likely responsible. I still don't know who created them. So, we may have competition for control of them. I have to get full control. I have made the ones in the North Restoration area but I don't have a computer watching them. I sort of turned them loose. Now they are pulling something into the water there and it's turning red. Eck. I've to figure out what is going on with that.
-
-One of the Devokan islands is breaking up, lots of lava and steam. I heard Dot was concerned. She probably is all over Quin to fix it... but, I think the island is lost. A huge ship is being built in open water. I hear Paislee is decorating it. I look forward to seeing what she does.
-
-I better go check the computers...
-------
-
-<pb>:::  M A Y  :::
-=== May 5 ===
-The blight seems to be spreading and changing in nature. Skysong is now affected as well as Devokan Touchstone. As a precaution I have moved my sky laboratory from Skysong to Curiosity.
-
-
-=== May 10 ===
-Using some of warrior Nalates' adaptations of the spheres, Mr Mahogany and I have been able to move what was in the region of Waysmeet to safety. It is now to the east of Curiosity.
-
-In an attempt to contain the spread of the blight, we have placed a containing dome over the main island of Skysong. Devokan Touchstone is probably too far gone to be saved.
-
-
-=== May 17 ===
-Over the past week, another island has been taken out of the path of the blight: Deepwater. It is now south of the transferred Waysmeet. The view from Deepwater looking across to Waysmeet and Curiosity is beautiful -- such a contrast to what is happening further north.
-
-The blight continues to affect Skysong. The containing dome might have slowed it a little, but each day more of the landscape succumbs to its poison.
-
-
-<pb>=== May 20 ===
-Matters are coming to a head. Using some of the same processes that seem to power the spheres Mr Mahogany and I have been able to transport the two islands so far unaffected by the blight to new places -- one of them being Devokan Waysmeet.
-
-However, Devokan Touchstone is lost, totally submerged. The fluxions above it -- most in the visual wavelengths -- are quite spectacular against the dark night sky.
-
-The dome placed over Skysong has only slowed, not halted, the blight's progress; chasms are appearing now, as they did when Touchstone was first affected.
-
-We have decided that the only option left is to wipe both Touchstone and Skysong from the map. This will take place within a week.
-
-
-=== May 25 ===
-This evening I watched the last direct link I had with my old home sink beneath an alien ocean. And as my companion talked about his dreams and hopes for the future, I witnessed my own being torn apart -- everything I had worked so hard to save and preserve all those months ago, utterly destroyed.
-
-When the end finally came, and Devokan Touchstone and Skysong were no more, I turned aside, muttered some excuse and linked back to Winterfell, seeking solace in work.
-
-
-<pb><pb><font size=24 face=Atrus color=000000><p align=center>
-te gloahloy
-kenen zuoy
-
-In my beginning 
-is my end
-
-Why? 
-Why such destruction?
-
-<pb><font size=20 face=Atrus color=000000>
-First my home world of Devokan 
-scorched by its sun
-
-Then the island of Devokan Touchstone
-transferred by the spheres
-destroyed by fiery blight
-
-Then the island of Skysong 
-the island I had chosen for my home
-swallowed by fire
-
-Can you see why 
-I try to restore what was lost?
-Even here, here in Serene?
-
-]]></translation>
-			</element>
-		</set>
-	</age>
+And with that, I linked out. Maybe Deepwater could make me feel better.]]></translation>
+            </element>
+        </set>
+    </age>
 </localizations>


### PR DESCRIPTION
Changed from Devokan story to the curated Serene-related journal written by Andy Legate, so the contents will match what is on MOULa since the Q4 2021 release. Edits for grammar and typos by Dot, Adam, and myself.

I'd be happy to rebase if needed after #190 has been merged, which will allow the diff to work properly as it will be comparing UTF-8 to UTF-8 before and after.