### PR TITLE
Add Cannen Filter to Veelay Music

### DIFF
--- a/compiled/sfx/psnlVeeTsahMusic.ogg
+++ b/compiled/sfx/psnlVeeTsahMusic.ogg
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98ca2577bfbf812e94c74a5f606d18f4d8417174b6bc9e0f871f40a66c2e1967
-size 3817928
+oid sha256:0eef431586ad44bda251e93099821e72216d0ea2cfab7486b4d45a7ff4f363e5
+size 4279212


### PR DESCRIPTION
With Mystler's blessing, retroactively applies the new cannen filtering effect to Relto's Veelay track. Going forward, these will be standardized and all new cannen tracks should use this same filter.

I apologize I was unable to properly upload this with Git LFS - I ran into issues getting this to work and had to resort to GitHub frontend instead. I will need someone to make the needed correction for me.