### PR TITLE
Fix Serene Journal GUI Cover

### DIFF
--- a/compiled/dat/Serene.loc
+++ b/compiled/dat/Serene.loc
@@ -3,7 +3,7 @@
     <age name="Serene">
         <set name="Journals">
             <element name="thejournal_DRAW">
-                <translation language="English"><![CDATA[<margin right=30 left=50 top=30>
+                <translation language="English"><![CDATA[<cover src="serenejournal.hsm"><margin right=30 left=50 top=30>
 <font size=18 face=Michelle color=221166><pb><p align=left>June 9th
 I took a small makeshift boat, and decided to head for a spot in the wall of the cavern. I found a small cave where I landed and wandered around, lost, for a day or two, when I stumbled upon a bigger cave with a walkway. As I made my way down it, when I got to a certain point, a gate came crashing down and I have not been able to get it opened back up. This walkway led to the Atrium of Neolbah. Fortunately, there was a Nexus linking pedestal there with a book going to the Nexus and, by using it, I was able to have a link to this place included in my KI.
 

--- a/compiled/dat/Serene_District_Textures.prp
+++ b/compiled/dat/Serene_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:39dd88d8bbae52e33ff4a4d8ab23e503bf15f79706f3201f7616a97a63a8d639
-size 7498562
+oid sha256:f294aaf2714d85bbbb92ffc2e8097ca8d8a327ec4e063620a4c73fd3e5a1bc74
+size 7761712

--- a/compiled/dat/Serene_District_mainRoom.prp
+++ b/compiled/dat/Serene_District_mainRoom.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c61d717b981e446ef92efd53e2d07804e69a1c99d4bc628174c113ab9b0d196
-size 27138601
+oid sha256:dad9c688dbd7ed11a8262cd63aff920fcbe5836aaf2127ac57bf5843ca5e89ad
+size 27286337


### PR DESCRIPTION
* Adds necessary texture for Serene's journal cover in the GUI and adds the `cover src` to the LOC. Fixes part of #211 (see comment about other journals mentioned).