### PR TITLE
Adds Additional Updates to Phil's Relto Book Textures

### DIFF
--- a/compiled/dat/philRelto_District_PhilsRelto.prp
+++ b/compiled/dat/philRelto_District_PhilsRelto.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:623565fa05bc86be42ae57ee551d9e2a8b7fb16f0f63ddda05120d5cbef4f449
-size 3940865
+oid sha256:a3e5df9663e2ef871d434d6b0fb87a70282dfc6fd16b084a50f229bb4e99854d
+size 4138285

--- a/compiled/dat/philRelto_District_Textures.prp
+++ b/compiled/dat/philRelto_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e20256a7b3de5a1b6ad4660471fab99923f9ef9144c76db22c6d9d0f4e702044
-size 12009552
+oid sha256:192c1fb4726f6fbd58b59e63069c134fd4cd2c28d9ba588a90999009bf02b56f
+size 12009548


### PR DESCRIPTION
Expands on @EhrenCG's work from Pull Request https://github.com/H-uru/moul-assets/pull/198 -

The underlying issue here was that the texture mapping used the original CC Relto mapping, despite the texture sheet provided for Phil's Relto being the exact same as MOUL's Relto, where most of the book textures have now been changed out for different ages. This resulted in several completely random books being shown in the POTS section on the shelf in Phil's Relto.

The solution in PR198 was to swap out the entire psnlbookcovers*40#0.hsm texture sheet with the CC one, which works, as it reverts the four POTS books to their textures from CC. However, we can take this change a step further by generating our own custom texture sheet designed specifically for Phil's Relto. Doing so allows us to make the following additional adjustments included in this PR:

1. Phil's Relto is actually supposed to use an inverted green variant of the hood book for Kirel. This is now fixed in this PR, by swapping out the equivalent Hood book texture.
2. Updates the cover designs for the four non-GTP books with the equivalent retconned re-designs from MOUL, for consistency - as much as I like the CC textures, Cyan deliberately redesigned these four books for a reason, and I feel we should honor that. I feel fairly confident this would have been the authorial intent, had Phil's Relto been tested a little more thoroughly originally.

Vanilla:
![image](https://user-images.githubusercontent.com/6642931/222925417-bb26b74d-c35a-4b7d-9dcc-5ee8f3fdeabe.png)

After PR198:
![image](https://user-images.githubusercontent.com/6642931/222925434-c91e3085-7078-4908-8e18-95a4e396ad2a.png)

And after this PR:
![Shelf](https://user-images.githubusercontent.com/6642931/222925525-816b130d-a767-4e8a-a65f-2a65ac987099.png)