### PR TITLE
Interim Fix for Hood/Kirel Skybox Streaking

### DIFF
--- a/compiled/dat/Neighborhood02_District_Textures.prp
+++ b/compiled/dat/Neighborhood02_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:29a19c3bbde8819b8ab56e3e9a3cc7d6c333381b68c34d32ef426be1972c3b2d
-size 31877744
+oid sha256:e368e5e68b9cb7e7a39be677a318834077f64b4719e810dcde1df5c11f182921
+size 31877728

--- a/compiled/dat/Neighborhood_District_Textures.prp
+++ b/compiled/dat/Neighborhood_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cd51838efe60fdfa7ff14ef99c0016098cde924785eaf41ce304432aaacd9e3
-size 45976796
+oid sha256:80ce662696ebb02ac5ab50542595d091b22a3d9899ca5f317e6078f52b785424
+size 45976780


### PR DESCRIPTION
Revises the City Wall texture used in nb01/nb02 to remove details that would cause streaks in the overhead skybox. This new texture was sourced from the high-definition version of this same graphic contained in Intangibles files to prevent unnecessary loss from compression.

This is an **interim fix**, and is intended to be replaced by the more involved mesh, uv and texture fixes developed by @Hazado, @Emor-Dni-Lap et al. as part of #52 **Lake Lighting Project** once they are ready - Hazado has indicated this interim fix is OK in the meantime.

Before:
![image](https://user-images.githubusercontent.com/6642931/233239900-f6050546-7ef2-436e-9fba-d76f49ee56b8.png)

After:
![image](https://user-images.githubusercontent.com/6642931/233239945-2b1d0f35-aa8d-436e-a669-265df666ff7d.png)

