### PR TITLE
Add contributing guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ We use GitHub's [issue tracker](https://github.com/H-uru/moul-assets/issues) to 
 - any other pertinent notes, such as why you think the issue is happening and any mitigation you attempted
 
 ## Submitting Changes
-Changes to moul-assets generall fall under two categories: objective and subjective. Before submitting any changes to the repository, you will need to [request access](https://guildofwriters.org/assets_repo) to the LFS store.
+Changes to moul-assets generally fall under two categories: objective and subjective. Before submitting any changes to the repository, you will need to [request access](https://guildofwriters.org/assets_repo) to the LFS store.
 
 ### Submitting Objective Changes
 Objective changes tend to be limited in scope and are generally minor adjustments or fixes to content already accepted to the repository. These changes should require limited discussion and should demonstrate a clear and apparent improvement to the game. These changes may be developed and submitted using [GitHub Flow](https://guides.github.com/introduction/flow/index.html). To propose changes to the repository:
@@ -50,7 +50,7 @@ Objective changes tend to be limited in scope and are generally minor adjustment
 ### Submitting Subjective Changes
 Subjective changes tend to be larger in scope, such as a new Age or expansion of a previously existing Age, and generally require discussions around myriad aspects of their development. This can be a lengthy process involving many revisions to your contribution. For this reason, we do not accept pull requests for subjective changes until the changes have gone through an external content review process. There is currently no accepted content review process; we leave it up to the contributor to revise their content with discerning member(s) of the Age creation and development community. For a subjective change to be considered, an endorsement from at least *one* (1) discerning member of the Age creation and development community must be provided. If you need assistance with identifying a process or a discerning member, contact a [maintainer](https://github.com/H-uru/moul-assets/people).
 
-Subjective changes to the game are, by their very nature, subjective, hence our relucance to impose and document a specific review process. However, all subjective submissions should:
+Subjective changes to the game are, by their very nature, subjective, hence our reluctance to impose and document a specific review process. However, all subjective submissions should:
 - be relatively bug-free
 - be tested against the Myst Online: Uru Live version of the [Plasma Engine](https://github.com/H-uru/Plasma) by the creator (at minimum)
 - match the art style of the currently accepted content both visually and audibly

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,8 @@ The goal of the moul-assets project is to provide baseline assets for the MMORPG
 - avoiding nontrivial breaks in compatibility with the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
 
 Further, we have identified these non-goals:
-- accepting all fan created content
-- accepting fan created content published on any particular shard, including the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
+- accepting all fan-created content
+- accepting fan-created content published on any particular shard, including the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
 - accepting fan content geared toward role-playing done on any particular shard, including the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
 - supporting exploit-based gameplay
 
@@ -28,7 +28,7 @@ Real-time discussion with team members and other contributors is an excellent wa
 - Server: irc.guildofwriters.org:6667
 - Channel: #writers
 
-We also use the [Guild of Writers' forum](https://forum.guildofwriters.org/viewforum.php?f=3) for more permanent discussions. Further, many team members can also be found on the [OpenUru discord](https://discord.com/invite/tVknpHQ).
+We also use the [Guild of Writers' forum](https://forum.guildofwriters.org/viewforum.php?f=3) for more permanent discussions. Further, many team members can also be found on the [OpenUru Discord](https://discord.com/invite/tVknpHQ).
 
 ## Reporting Bugs and Requesting Features
 We use GitHub's [issue tracker](https://github.com/H-uru/moul-assets/issues) to list bugs and feature requests. Good bug reports tend to have:
@@ -52,7 +52,7 @@ Subjective changes tend to be larger in scope and generally require discussions 
 
 Subjective changes to the game are, by their very nature, subjective, hence our reluctance to impose and document a specific review process. However, all subjective submissions should:
 - be relatively bug-free
-- be tested against the Myst Online: Uru Live version of the [Plasma Engine](https://github.com/H-uru/Plasma) by the creator (at minimum)
+- be tested against the current H'uru version of the [Plasma Engine](https://github.com/H-uru/Plasma) by the creator (at minimum)
 - match the art style of the currently accepted content both visually and audibly
 - not look like a "video game"
 - have largely correct lighting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing
+We are glad that you are interested in contributing to moul-assets! We happily accept contributions, including:
+- bug reports
+- bug fixes
+- art assets
+- and much more!
+
+Please take a moment to read these guidelines to ensure your contributions are accepted.
+
+## Project Goals
+The goal of the moul-assets project is to provide baseline assets for the MMORPG [Myst Online: Uru Live](https://mystonline.com) to be used in the [Plasma Engine](https://github.com/H-uru/Plasma). In the interest of doing so, we have identified these project goals:
+- providing a coherent, well-tested content baseline for [Myst Online: Uru Live](https://mystonline.com) shard operators
+- conservatively improving the base game Ages as created by Cyan Worlds, Inc. with objective bug fixes and enhancements
+- improving the player experience
+- integrating new content/Ages that serve a clear purpose in enhancing Myst Online: Uru Live as a video game
+- avoiding nontrivial breaks in compatibility with the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
+
+Further, we have identified these non-goals:
+- accepting all fan created content
+- accepting fan created content published on any particular shard, including the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
+- accepting fan content geared toward role-playing done on any particular shard, including the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
+- supporting exploit-based gameplay
+
+These are tasks that run contrary to the project's priorities stated above, and as such are not likely to be accepted if submitted for inclusion. Any changes implementing these are best maintained on an independent fork.
+
+## Getting Involved
+Real-time discussion with team members and other contributors is an excellent way to begin contributing. We welcome feedback and discussion of proposed changes. Active maintainers can be found on the Guild of Writers IRC channel:
+- Server: irc.guildofwriters.org:6667
+- Channel: #writers
+
+We also use the [Guild of Writers' forum](https://forum.guildofwriters.org/viewforum.php?f=3) for more permanent discussions. Further, many team members can also be found on the [OpenUru discord](https://discord.com/invite/tVknpHQ).
+
+## Reporting Bugs and Requesting Features
+We use GitHub's [issue tracker](https://github.com/H-uru/moul-assets/issues) to list bugs and feature requests. Good bug reports tend to have:
+- a summary or background
+- steps to reproduce the bug, the more specific, the better!
+- what you expect to happen
+- what actually happens
+- any other pertinent notes, such as why you think the issue is happening and any mitigation you attempted
+
+## Submitting Changes
+Changes to moul-assets generall fall under two categories: objective and subjective. Before submitting any changes to the repository, you will need to [request access](https://guildofwriters.org/assets_repo) to the LFS store.
+
+### Submitting Objective Changes
+Objective changes tend to be limited in scope and are generally minor adjustments or fixes to content already accepted to the repository. These changes should require limited discussion and should demonstrate a clear and apparent improvement to the game. These changes may be developed and submitted using [GitHub Flow](https://guides.github.com/introduction/flow/index.html). To propose changes to the repository:
+- fork the repository and make your changes as described by GitHub flow
+- open a pull request and ensure that all test coverage and continuous integration passes
+- document in the pull request body what you have changed and why
+
+### Submitting Subjective Changes
+Subjective changes tend to be larger in scope, such as a new Age or expansion of a previously existing Age, and generally require discussions around myriad aspects of their development. This can be a lengthy process involving many revisions to your contribution. For this reason, we do not accept pull requests for subjective changes until the changes have gone through an external content review process. There is currently no accepted content review process; we leave it up to the contributor to revise their content with discerning member(s) of the Age creation and development community. For a subjective change to be considered, an endorsement from at least *one* (1) discerning member of the Age creation and development community must be provided. If you need assistance with identifying a process or a discerning member, contact a [maintainer](https://github.com/H-uru/moul-assets/people).
+
+Subjective changes to the game are, by their very nature, subjective, hence our relucance to impose and document a specific review process. However, all subjective submissions should:
+- be relatively bug-free
+- be tested against the Myst Online: Uru Live version of the [Plasma Engine](https://github.com/H-uru/Plasma) by the creator (at minimum)
+- match the art style of the currently accepted content both visually and audibly
+- not look like a "video game"
+- have largely correct lighting
+
+Ensuring contributions meet these criteria should be done as part of the preliminary review process done outside of this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The goal of the moul-assets project is to provide baseline assets for the MMORPG
 - providing a coherent, well-tested content baseline for [Myst Online: Uru Live](https://mystonline.com) shard operators
 - conservatively improving the base game Ages as created by Cyan Worlds, Inc. with objective bug fixes and enhancements
 - improving the player experience
-- integrating new content/Ages that serve a clear purpose in enhancing Myst Online: Uru Live as a video game
+- integrating new content that serve a clear purpose in enhancing Myst Online: Uru Live as a video game
 - avoiding nontrivial breaks in compatibility with the official **Myst Online: Uru Live (again)** game run by Cyan Worlds, Inc.
 
 Further, we have identified these non-goals:
@@ -48,7 +48,7 @@ Objective changes tend to be limited in scope and are generally minor adjustment
 - document in the pull request body what you have changed and why
 
 ### Submitting Subjective Changes
-Subjective changes tend to be larger in scope, such as a new Age or expansion of a previously existing Age, and generally require discussions around myriad aspects of their development. This can be a lengthy process involving many revisions to your contribution. For this reason, we do not accept pull requests for subjective changes until the changes have gone through an external content review process. There is currently no accepted content review process; we leave it up to the contributor to revise their content with discerning member(s) of the Age creation and development community. For a subjective change to be considered, an endorsement from at least *one* (1) discerning member of the Age creation and development community must be provided. If you need assistance with identifying a process or a discerning member, contact a [maintainer](https://github.com/H-uru/moul-assets/people).
+Subjective changes tend to be larger in scope and generally require discussions around myriad aspects of their development. This can be a lengthy process involving many revisions to your contribution. At this time, we are not interested in unsolicted submissions of new Ages. New Ages should be submitted to the individual Shard(s) that you would are interested in Age appearing on.
 
 Subjective changes to the game are, by their very nature, subjective, hence our reluctance to impose and document a specific review process. However, all subjective submissions should:
 - be relatively bug-free
@@ -56,5 +56,3 @@ Subjective changes to the game are, by their very nature, subjective, hence our 
 - match the art style of the currently accepted content both visually and audibly
 - not look like a "video game"
 - have largely correct lighting
-
-Ensuring contributions meet these criteria should be done as part of the preliminary review process done outside of this repository.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is used to host assets used in Cyan World's Myst Online: Uru Liv
 * [korman](https://github.com/H-uru/korman) - Blender plugin for creating ages for Cyan Worlds' Plasma engine.
 
 ## Contributing
-This repository is intended to track large binary files where diffs are impractical. All binary objects are stored on the Guild of Writers server to avoid incurring additional fees from GitHub. To prevent abuse/spam, the ability to push binary objects is restricted to approved users, even in your own fork. If you would like to contribute to this repository, you can request access [here](https://guildofwriters.org/assets_repo).
+This repository is intended to track large binary files where diffs are impractical. All binary objects are stored on the Guild of Writers server to avoid incurring additional fees from GitHub. To prevent abuse/spam, the ability to push binary objects is restricted to approved users, even in your own fork. If you would like to contribute to this repository, you can request access [here](https://guildofwriters.org/assets_repo). A more detailed [contributing guide](CONTRIBUTING.md) is available.
 
 ## Source Assets
 Source assets in this repository must be complete and in a format that is trivial to export or compile for the Myst Online version of the Plasma engine. Therefore, the sources must be one of the following:


### PR DESCRIPTION
This repository exists in an odd state where it kinda matches MOULa but not really. So, I've written up a draft contributor guide that lays out where I think this repo should fall in the ecosystem. Specifically, we are not trying to be the MOULa repository - that's not been our goal, ever really. Our goal, generally speaking, has been to provide a high quality baseline for any shard to operate off of.

One of our main sources of difficulty is that a lot of things that have been tested on Minkata and deployed to MOULa. Unfortunately, Minkata is a testing environment, not a review environment. This has led to content going to Cyan's shard that, even in cases going back almost a decade, isn't particularly up to snuff with the rest of the game. This has been accelerating over the last couple of years and has been putting us in an awkward position where we have a lot of open pull requests whose purpose is basically to match what's on MOULa but not to actually receive feedback.

So, I've codified that we aren't trying to match MOULa exactly (but we also don't want to break it), and we also don't want to be the initial submission point for new Ages. There still isn't an official process, but this at least draws the line in the sand, so to speak, that we expect for content to go through some kind of review process. Ideally, this will be with community members that we know have a keen eye for details both in regard to canon and art. I'm not sure we should explicitly list those people out, so I labelled them as "discerning members" in the document.

With this guide in place, we will need to re-evaluate all fan content that we've accepted and determine whether or not it falls in line with the new guidelines. My initial observations are:
- Chiso: ***Accept*** - with the MOULa roleplay items from the lower floor removed from this repo. Could probaby be moved into a new PRP that we just simply don't include.
  - Endorsed by Hoikas
  - Provides important gameplay service of library Age
- Highgarden ***Revert***
  - Lacks an endorsement
- GoMePubNew ***Accept***
  - Endorsed by Hoikas... and possibly two others from the Gehn era
  - Provides important socialization space, matches the rest of the game content
- Kirel Speeches ***Reject***
  - violated specific shard roleplay rule 
- Serene ***Revert***
  - Lacks an endorsement
- Tiam ***Revert***
  - Lacks an endorsement
- trebivdil ***TBD***
  - is winning the RAD a sufficient endorsement?
-  Veelay ***Accept***
   - Endorsed by Hoikas... and possibly two others from the Gehn era
   - Provides important community space
- Vothol ***TBD***
   - is winning the DLC a sufficient endorsement?

Note that rejection does not necessarily mean that the Age or content is not good, rather, it doesn't comply with the procedure set forth for inclusion. I want to avoid personally endorsing anything new for the purpose of this PR, but there are some things that I endorsed back in the Gehn era.

When applying these rules to the open PRs, we need to **close** (with the potential for re-opening on endorsement):
- #233 (no endorsement)
- #230 (no endorsement)
- #212 (Serene is retroactively rejected)
- #210 (there is no accepted Age "Kalamee")
- #207 (no endorsement)
- #199 (no endorsement)
- #177 (no endorsement)
- #148 (no endorsement)
- #145 (no endorsement)
- #143 (no endorsement)
- #117 (no endorsement)
- #76 (no endorsement)
- #75 (no endorsement)
- #52 (no endorsement)

Finally, we'll probably want to seriously consider having another repository (or org) that tracks what's actually on MOULa. The goal of this repo/org won't be to act on pull requests. Rather, it should be a fork of both Plasma and moul-assets containing the code and assets required to play specifically MOULa using the superior client. Ideally, this would be unnecessary; however, OU continues to a roadblock in terms of actually progressing the ecosystem as a whole. It would be nice if we could farm the maintenance of that out to someone else (who isn't me)
