### PR TITLE
Asset Blend Files

### DIFF
--- a/sources/blends/CleftChair.blend
+++ b/sources/blends/CleftChair.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39575e83261a2f8cc0c96c10017b9c95b44bf47fc03e4428a802917278d94d9e
+size 3675672

--- a/sources/blends/CleftChairs.blend
+++ b/sources/blends/CleftChairs.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29469863ce444c8b842bcf97805e51de4078df832e808a4207327f3348c19cd7
+size 3695168

--- a/sources/blends/ConesBarricades.blend
+++ b/sources/blends/ConesBarricades.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:edbdc360a4bc5218151c056228d623f57957bed70ff5e679c13564a48d97ec29
+size 2087156

--- a/sources/blends/CrazyLamp.blend
+++ b/sources/blends/CrazyLamp.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a15552fe32664ea219d94def229bcb1fd0fc4ad14aa4bd77edcbdca4e8a465d3
+size 1187836

--- a/sources/blends/FlatLamps.blend
+++ b/sources/blends/FlatLamps.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0efa377eeb8a7629bc667472747cce1992106785a4ac029f5b9c86712ca177a
+size 3365952

--- a/sources/blends/Gazebo01.blend
+++ b/sources/blends/Gazebo01.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3bfd7b7822fda41f5e6a3e528eadef801a8d8295acc91c9a2ef1f4987a8d8957
+size 3363724

--- a/sources/blends/Gazebo02.blend
+++ b/sources/blends/Gazebo02.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6c54a2e64a8fe2bd5111d977106c64ea99f8a6b8b64b6f039bbb1e359de0d4a
+size 2305396

--- a/sources/blends/Gazebo03.blend
+++ b/sources/blends/Gazebo03.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb7842ec8c60561d80fc3d72dae3fd5a657517f9796a4f836866db08a2bce774
+size 1638404

--- a/sources/blends/GuildBanners.blend
+++ b/sources/blends/GuildBanners.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5860180e6c68c6e6ee91ca2a4d57e7fc308611a56a83d287939efe8d7a29c476
+size 1188464

--- a/sources/blends/GuildTapestries.blend
+++ b/sources/blends/GuildTapestries.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08b21191a4ef7600702e65a592bc6eb88b5607e5da31aa495dee4439699d0839
+size 3048664

--- a/sources/blends/HoodEntryway.blend
+++ b/sources/blends/HoodEntryway.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc28817e95d54ff62781133b0fc2cdcda661f7c0878f4890e782548385ee3c9b
+size 6900704

--- a/sources/blends/Lamp01.blend
+++ b/sources/blends/Lamp01.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:09b2d293de219a745d51d5e6c7ef8548750cd2cda7572540541abcab7125d902
+size 1031200

--- a/sources/blends/NexusPedestal.blend
+++ b/sources/blends/NexusPedestal.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:decf9e15519d59b09bf7245b8e1ea825632526fb790288e47093481afe8db643
+size 2678196

--- a/sources/blends/NexusPedestalHooded.blend
+++ b/sources/blends/NexusPedestalHooded.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f33147962eb2423394e1e3637b30bd0a9ad3b31e7fc6773ea933096a205cdd6
+size 985628

--- a/sources/blends/Pedestal01.blend
+++ b/sources/blends/Pedestal01.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cc1626cf2b9ae3666c50693da9f5d45110095897489ccbf88175cc425b05287
+size 1217376

--- a/sources/blends/Signpost.blend
+++ b/sources/blends/Signpost.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:782e1f20f9c3bc07156319a3fe7ff65167242068aa59a09a53c2084e4e31b312
+size 2754068

--- a/sources/blends/Statue01.blend
+++ b/sources/blends/Statue01.blend
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f56ba167d05f3c94c670dd746ab7e3a9fe338d1ff5c1cddd989acb1373d028d
+size 3519972


### PR DESCRIPTION
This is an initial commit of blend files containing assets from various Cyan Ages (and also the new GoMe Pub).

These include:

* Zandi's chairs from the cleft (two files: single chair and two chairs)
* Several types of construction cones and barricades
* The "crazy lamp" found in Ae'gura in places such as outside the museum door
* The "flat" lamps from the hoods (Bevin, Seret/Kirel, and a blank one)
* Three different gazebo files (roof w/ lights on, roof w/ lights off, no roof w/ Linking Book)
* Various banners from the new GoMe Pub (Guild, Cyan-related, Pride, etc, plus one blank)
* Guild tapestries from the five Cyan Pubs (plus one blank)
* The entryway from the hoods
* Lamp found in a few of the Eders
* Two versions of the Nexus pedestal: one "hooded" (like next to library in Ae'gura) and one for walls (ie no back mesh)
* Simple Book pedestal (eg the pedestal next to the KI machine in Gahreesen with the Nexus Book)
* Signpost with arrows from Ae'gura
* Large ornamental statue from various garden Ages.

The blends come with both the license and instructions displayed and should contain all the needed textures. If something is missing, that can be remedied in future commits.

Also, I took a guess as to what we'd want for the file structure, but that can be easily modified too, of course.

Any thoughts and suggestions on this new process are most welcome!