### PR TITLE
Remove newlines causing weird spacing and missing signature on Nick's note

### DIFF
--- a/compiled/dat/CityEnglish.loc
+++ b/compiled/dat/CityEnglish.loc
@@ -1443,12 +1443,9 @@ And don't lose it. I could barely get it off the wall and when I did, it was pre
 </translation>
 			</element>
 			<element name="NickNote">
-				<translation language="English">
+				<translation language="English">Where the heck is my book? And why did someone take it in the first place!
 
-Where the heck is my book? And why did someone take it in the first place!
-
-- Nick 
-
+- Nick
 </translation>
 			</element>
 			<element name="WatsonLetter">

--- a/compiled/dat/CityFrench.loc
+++ b/compiled/dat/CityFrench.loc
@@ -1365,12 +1365,9 @@ Mais il ne faut pas le perdre. J'ai eu beaucoup de mal à l'enlever du mur, ce q
 </translation>
 			</element>
 			<element name="NickNote">
-				<translation language="French">
+				<translation language="French">Où est passé mon Livre ? Pourquoi quelqu'un l'a-t-il pris !
 
-Où est passé mon Livre ? Pourquoi quelqu'un l'a-t-il pris !
-
-- Nick 
-
+- Nick
 </translation>
 			</element>
 			<element name="WatsonLetter">

--- a/compiled/dat/CityGerman.loc
+++ b/compiled/dat/CityGerman.loc
@@ -1403,12 +1403,9 @@ Und verlier es nicht. Ich habe es kaum von der Wand bekommen und als ich es endl
 </translation>
 			</element>
 			<element name="NickNote">
-				<translation language="German">
+				<translation language="German">Wo zur Hölle ist mein Buch? Wer hat überhaupt etwas da dran zu suchen?!
 
-Wo zur Hölle ist mein Buch? Wer hat überhaupt etwas da dran zu suchen?!
-
-- Nick 
-
+- Nick
 </translation>
 			</element>
 			<element name="WatsonLetter">

--- a/compiled/dat/CityItalian.loc
+++ b/compiled/dat/CityItalian.loc
@@ -460,12 +460,9 @@ E non perderlo. Sono a malapena riuscito a staccarlo dal muro e, quando l'ho fat
 </translation>
 			</element>
 			<element name="NickNote">
-				<translation language="Italian">
+				<translation language="Italian">Dove diavolo è il mio libro? Ma soprattutto, perchè qualcuno l'ha preso?
 
-Dove diavolo è il mio libro? Ma soprattutto, perchè qualcuno l'ha preso?
-
-- Nick 
-
+- Nick
 </translation>
 			</element>
 			<element name="WatsonLetter">

--- a/compiled/dat/CitySpanish.loc
+++ b/compiled/dat/CitySpanish.loc
@@ -458,12 +458,9 @@ Y no lo pierdas. Me costó mucho retirarlo de la pared y cuando lo hice, me dio 
 </translation>
 			</element>
 			<element name="NickNote">
-				<translation language="Spanish">
+				<translation language="Spanish">¿Dónde demonios está mi libro? ¡¿Y por qué se lo tuvo que llevar alguien?!
 
-¿Dónde demonios está mi libro? ¡¿Y por qué se lo tuvo que llevar alguien?!
-
-- Nick 
-
+- Nick
 </translation>
 			</element>
 			<element name="WatsonLetter">


### PR DESCRIPTION
Reported by Theo in OpenUru discord. Nick's Takotah rooftop note had gotten shoved down the page such that the signature no longer showed. The in-world model of the note shows the signature, as does the version of the note in CC according to Harley. The odd spacing was present for all translations. If this change is accepted, I'll make a change suggestion for the affected Russian LOC in #237 as well.

Before:
![image](https://github.com/H-uru/moul-assets/assets/94947971/f1c6ec71-8a81-4c3d-8ff0-45a7bd68d56e)

After:
![image](https://github.com/H-uru/moul-assets/assets/94947971/8232bfcc-520e-47ff-a97e-b9161ab433e7)