### PR TITLE
Improve Green Storm Texture

### DIFF
--- a/compiled/dat/Personal_District_Textures.prp
+++ b/compiled/dat/Personal_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4faabd8cb957d93a225cd60054b6229a3dbc83e47440fb193d1e7f35859e56a7
-size 45236117
+oid sha256:950a5ddc50a4a38568359568b83adae888d2bc0eda8b6266364b755942ae69b4
+size 45236133

--- a/sources/textures/tga/Personal/psnlnewsky3verydark_40#2.png
+++ b/sources/textures/tga/Personal/psnlnewsky3verydark_40#2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd12b061e74abea11f096ce94e3b82979299a8728a9c975680b0ebf76880dc24
+size 283002


### PR DESCRIPTION
Improves the variant of the stormy cloud texture Relto uses when the while the "green sky" (Veelay) page is active.

This is the counterpart to [content/145](https://foundry.openuru.org/gitblit/tickets/?r=MOULa-current-content.git&h=145) in the OpenUru Foundry, included in the Q3 2024 update to MOULa. However, there are some notable differences to be aware of, due to OU/MOULa and H'uru/moul-assets being slightly out of sync:
1. OU contains an optimization made by @Hazado which splits out all the fan content into separate PRPs so they are more modular, but this change is not present in H'uru/moul-asets yet. As such, the equivalent change here is applied directly to **Personal_District_Textures** rather than **Personal_District_psnlFanYeeshaPages01**, as the asset in question has not been split off from the _Textures file and repackaged into _psnlFanYeeshaPages01 in the version currently on H'uru/moul-assets.
2. There is a known issue where the sun and moon objects do not display properly through the cloud layer, and this is especially noticeable here. @Hazado added a fix which is currently on OU/MOULa adjusting the layer the objects are drawn in which fixes this issue, but H'uru/moul-assets does not have this fix yet. As such the sun and moon will not be visible while this "stormy veelay" variant is active.