### PR TITLE
Cleft Texture Improvements (Zandi Props & Skybox)

### DIFF
--- a/compiled/dat/Cleft_District_Textures.prp
+++ b/compiled/dat/Cleft_District_Textures.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fceec4a3b884c772e559c0f73e8c2e534ce0c9c66c3b7dc0e8c12a89c4586727
-size 35044682
+oid sha256:14e5121930a9c70e7991ab2f632b7b2000b61ba45317f1769cf8cbfddc694390
+size 37242158

--- a/sources/textures/tga/Cleft/clftBeerCan.png
+++ b/sources/textures/tga/Cleft/clftBeerCan.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cb2a1aad9ad6ddae2877760b1240e459cebe3e705c6e5d01b957098589d31920
+size 26580

--- a/sources/textures/tga/Cleft/clftBeerCan.tga
+++ b/sources/textures/tga/Cleft/clftBeerCan.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:21b5f4014187406bc24c297a206a0f2958010a2802e5d8cb4804d1cc1244972a
-size 65580

--- a/sources/textures/tga/Cleft/clftChipsBag.png
+++ b/sources/textures/tga/Cleft/clftChipsBag.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6ab71bfa54449d84026b963df0b929670c97de818e3046d52cae2a1ca235eed
+size 30894

--- a/sources/textures/tga/Cleft/clftChipsBag.tga
+++ b/sources/textures/tga/Cleft/clftChipsBag.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c63281cf0a91c00bcaf96a83ab7abf96fc4c2ab08fc76a6c3a85ec90f5e2b09
-size 49196


### PR DESCRIPTION
Equivalent to [Commit 0a34a4](https://foundry.openuru.org/gitblit/commit/?r=MOULa-current-content.git&h=0a34a4d81595ec5d08e70504269a55b2a3a1cec2) of [content/144 ("Cleft Revamp Bundle 1")](https://foundry.openuru.org/gitblit/tickets/?r=MOULa-current-content.git&h=144) in the OpenUru Foundry, included in the Q3 2024 update to MOULa. (For submission to H'uru I am splitting this bundle into three separate PRs for increased modularity.)

First batch of a planned series of improvements to help modernize The Cleft:
- Gives "ClftBeerCan" a facelift that reads more clearly as a water bottle and makes sure the "Sponakee" joke is actually legible.
- Slightly bumps up the res on ClftCD so this reads more clearly.
- In keeping with MOUL's intended "current day" setting, gives ClftChipsBag a "modernized" redesign (created entirely from scratch with 100% original assets) so Zandi does not appear to be eating from a 30-year-old bag.
- Slightly bumps up the res on ClftRadioMap (but only _slightly_ - the full res we have available in the original assets is _far_ larger than is necessary.)

In addition: The Cleft's skybox appears noticeably lower-res compared to other ages, which is unfortunate as this is a very important location. To address this, this change bumps up the res on ClftSky3 to the original texture resolution (2x). (Note: @Hoikas and I investigated various compression methods on this and were unable to find one that did not introduce any noticeable artifacts to the in-game sky - so I can understand if that makes this particular change controversial/unacceptable for H'uru/moul-assets.)

Note: I assessed several other objects in my tests as well, such as the chair, table grain, grill, cooler, etc, but did not find that there was any noticeable or worthwhile improvement in these cases - the set I've prepared here seem to be the only of Zandi's props that actually benefit from TLC.

![image](https://github.com/user-attachments/assets/7956e79c-cf06-4a00-9d60-73248c9f3900)
![image](https://github.com/user-attachments/assets/58ee5995-5889-4203-a717-4207457d2e24)

![image](https://github.com/user-attachments/assets/2b0a572e-9c79-44a1-a98f-a80acf3d5cf9)
![image](https://github.com/user-attachments/assets/7b1287e9-0672-4657-9822-7b16522a61b0)
