### PR TITLE
FemaleHandsOptionsColorsFix

### DIFF
--- a/compiled/dat/GlobalClothing_District_Female.prp
+++ b/compiled/dat/GlobalClothing_District_Female.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:eddd63e47d6dc28a1e6b669f55be7d3dd825ce0f9bfe265f075e0e7139a5b9ea
-size 4731529
+oid sha256:50a9a17154035b8227a38e9ace222b033c5add70481ddde0ea0010cbb945f0ed
+size 4731704

--- a/sources/avatar/clothing/bas.avatar.female.max
+++ b/sources/avatar/clothing/bas.avatar.female.max
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d34cabe16b5d8d4176180f66798b7300261799556409f95d1b4ed7b159763a7d
-size 4562944
+oid sha256:be5d0a676cd760b0f63b3da134c0ad91dc4f79d8f3e18029d86d7faf82ebff37
+size 5021696


### PR DESCRIPTION
Fix the Female avatar's Hands Options colors switch when selecting a different Hands Option:

The fix constist to put the Nails color in the layer 1 and to put the Gloves color in the layer 2,
for both the Fingerless Gloves and the Canvas Gloves.
It have been done in the "sources\avatar\clothing\bas.avatar.female.max" file with "3DS Max 2022", and then the "compiled\dat\GlobalClothing_District_Female.prp" file have been exported from the MAX file.