### PR TITLE
NoLinkOutGlobalAnimation

### DIFF
--- a/compiled/dat/GlobalAnimations_District_FemaleNoLinkOut.prp
+++ b/compiled/dat/GlobalAnimations_District_FemaleNoLinkOut.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ad782d545e5e77b44edd3704c956308b9ff4241c867d19feab07f981354f212d
+size 30286

--- a/compiled/dat/GlobalAnimations_District_MaleNoLinkOut.prp
+++ b/compiled/dat/GlobalAnimations_District_MaleNoLinkOut.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c482f90ba36217f40f5dd864bf5e9ef25a6861f42741611b4370c80461ef325d
+size 66038


### PR DESCRIPTION
Add the "NoLinkOut" GlobalAnimations:

I have 2 PRPs for a new GlobalAnimations (`GlobalAnimations_District_[Gender]NoLinkOut.prp`) which I'll need for my "Trigon" Age, but this Age isn't ready yet; that being said, as these animations are global ones, someone could use them in his own Age.

These animations play forward the "LinkOut" animations without the final loop, keep the avatar with his hand raised for about 2 seconds, and play backward the "LinkOut" animations (still without the loop).
Here is a vidéo of the animations: https://youtu.be/_UdFXcMbWjE

They look a little like the "InsertKiHandLonger" animations, but with the right hand instead of the left hand.
It could be used in-game for different things.

Changes: `GlobalAnimations_District_FemaleNoLinkOut.prp` and `GlobalAnimations_District_MaleNoLinkOut.prp` new files.

- Development for POTS: `Sirius` > His email address isn't written on his profile. ( @Jrius )
- Convertion for MOUL & Edit: `TheScar(.fr) <thecleftbeyondthescar@gmail.com>` ( @TheScarFr )
- Convertion fixes: `Ehren <EhrenCG@hotmail.com>` ( @EhrenCG )

See also: https://github.com/H-uru/Plasma/pull/1636