### PR TITLE
Adjust Translations for "Big Blues" Attributions

### DIFF
--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -284,7 +284,7 @@ Celia Pearce
 <font size=24 spacing=-10><p align=center>Friends of Sironka Dance Troupe
 Certains sons et enregistrements vocaux sont fournis par The Friends of Sironka Dance Troupe, sous licence nonexclusive de Cyan, utilisé avec leur autorisation.
 
-<font size=24 spacing=-10>"Big Blues" - Jason Shaw, Audionautix.com
+<font size=24 spacing=-10>"Big Blues" par Jason Shaw sur Audionautix.com
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>FaceGen Modeller 2.1

--- a/compiled/dat/GlobalFrench.loc
+++ b/compiled/dat/GlobalFrench.loc
@@ -284,7 +284,7 @@ Celia Pearce
 <font size=24 spacing=-10><p align=center>Friends of Sironka Dance Troupe
 Certains sons et enregistrements vocaux sont fournis par The Friends of Sironka Dance Troupe, sous licence nonexclusive de Cyan, utilisé avec leur autorisation.
 
-<font size=24 spacing=-10>"Big Blues" par Jason Shaw sur Audionautix.com
+<font size=24 spacing=-10>« Big Blues » par Jason Shaw sur Audionautix.com
 
 <font spacing=-18>
 <font size=24 spacing=-10><p align=center>FaceGen Modeller 2.1

--- a/compiled/dat/GlobalGerman.loc
+++ b/compiled/dat/GlobalGerman.loc
@@ -461,7 +461,7 @@ VP Produktion<font spacing=-5>
 Bestimmte Musikpasssagen und Gesang von Friends of Sironka Dance Troupe, Verwendung mit freudlicher Genehmigung unter nicht-exklusiver Lizenz durch Cyan.
 
 
-<font size=24 spacing=-10>"Big Blues" - Jason Shaw, Audionautix.com
+<font size=24 spacing=-10>"Big Blues" von Jason Shaw auf Audionautix.com
 
 Didier Lord
 Ausführender Leiter Ubi Music

--- a/compiled/dat/GlobalItalian.loc
+++ b/compiled/dat/GlobalItalian.loc
@@ -411,7 +411,7 @@ VP della produzione<font spacing=-5>
 Alcuni suoni e voci forniti da Friends of Sironka Dance Troupe, sotto licenza non esclusiva di Cyan, usati dietro autorizzazione.
 
 
-<font size=24 spacing=-10>"Big Blues" - Jason Shaw, Audionautix.com
+<font size=24 spacing=-10>"Big Blues" di Jason Shaw su Audionautix.com
 
 <pb><font size=26><p align=center>Note legali (Tools)<font spacing=-5>
 <font spacing=-18>

--- a/compiled/dat/GlobalSpanish.loc
+++ b/compiled/dat/GlobalSpanish.loc
@@ -412,7 +412,7 @@ VP of Production<font spacing=-5>
 Las grabaciones de algunos de los sonidos y voces suministradas por Friends of Sironka Dance Troupe, son licencias no exclusivas de Cyan, usadas bajo autorización.
 
 
-<font size=24 spacing=-10>"Big Blues" - Jason Shaw, Audionautix.com
+<font size=24 spacing=-10>"Big Blues" por Jason Shaw en Audionautix.com
 
 <pb><font size=26><p align=center>Apartado Legal (Utilidades)<font spacing=-5>
 <font spacing=-18>


### PR DESCRIPTION
Very minor change: adjusts the translations for the "Big Blues" attributions using translations confirmed by fluent speakers who have been co-authored. Once approved, I will copy over this change & the other adjustments we made as part of #264 to OU for consistency.