### PR TITLE
Fix Nav Menu Header String Inconsistency

### DIFF
--- a/compiled/dat/GUI_District_NavigationSettingsDialog.prp
+++ b/compiled/dat/GUI_District_NavigationSettingsDialog.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3de5de2e36aaeaa4eb16047692ea295680b43b0e5e181c8ce5c4316362c2282c
-size 67318
+oid sha256:8c7ce5538cfeeb386f005432ae3d01d0f87bf9fb70db47f014e1ae9b835dc0ef
+size 67376

--- a/compiled/dat/OptionsMenuEnglish.loc
+++ b/compiled/dat/OptionsMenuEnglish.loc
@@ -234,7 +234,7 @@ Look Around - Right Mouse Drag
 				<translation language="English">Key Map</translation>
 			</element>
 			<element name="Navigation">
-				<translation language="English">Navigation
+				<translation language="English">Navigation Settings
 </translation>
 			</element>
 			<element name="Next">


### PR DESCRIPTION
Got a fun one here: in the current build of the Huru client, if you open each of the Options sub-menus, you'll notice the headers currently show as:
"Audio Settings"
"Graphic Settings"
"NAVIGATION SETTINGS"

![image](https://github.com/user-attachments/assets/1b6d9cca-ff9b-4a3d-880c-c5f820a8614b)


This is because when the Graphics & Audio Settings UIs were revised, they were adjusted to ensure that the header string pulls from the localization file, if available, rather than defaulting to the hard-coded ALL CAPS value in the PRP - but the Navigation Settings menu got no such optimization because there has been no need for a re-export.

This PR adjusts this inconsistency by telling the PRP to redirect to the LOC file for this string, consistent with how AudioSettings and GraphicsSettings handle this. 

![image](https://github.com/user-attachments/assets/40ba39dc-0340-4bbb-9873-1184772e2cdc)

I followed the pattern established by the other two menu updates, where the existing field for the main menu is leveraged for this field, but adjusted for consistency (in this case, we replace "Navigation" with "Navigation Settings" for consistency with the other two menus).

There is of course a *bigger* problem here, which is that all 3 of these menu items only have *English* strings in the LOC files, and have no international translations whatsoever - but this is a separate issue (and I'll probably open a ticket for this). In the meantime, this fix at least makes them _consistent_; but getting proper translations for each of these would probably need to come next.

I know you guys _generally_ prefer KI changes to be made in xKIGUI.max, but I figured since this is just a pretty simple, minor string pull, this ought to be a perfectly acceptable interim solution until such time as a re-export of the Navigation Settings menu is actually required - in which case that new export will simply supersede this.