### PR TITLE
Fix two more options menu text boxes not using loc files.

### DIFF
--- a/compiled/dat/GUI_District_NavigationSettingsDialog.prp
+++ b/compiled/dat/GUI_District_NavigationSettingsDialog.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3de5de2e36aaeaa4eb16047692ea295680b43b0e5e181c8ce5c4316362c2282c
-size 67318
+oid sha256:38e2ceedbba50078f6b78c0379416759ccb8aac06b5ff0db6c0edbff4ea90f33
+size 67446

--- a/sources/KI/xKIGUI.max
+++ b/sources/KI/xKIGUI.max
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:89a7345d55d65ab2a7e3be55cd53b197a86759d1ae66ae5b1998dcc6a5c8c24c
+oid sha256:d903e4864d4129f6f2b349d9ea0424478f8a7305f1fea17d873457c31f80b4dc
 size 11117642


### PR DESCRIPTION
Supersedes #280 by fixing the issue in the Max file.