### PR TITLE
Fix a couple of issues with BkBookImages.prp

### DIFF
--- a/compiled/dat/GUI_District_BkBookImages.prp
+++ b/compiled/dat/GUI_District_BkBookImages.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:957d797ec5ddd11b8b21b17f93e004a07c8b72637c4d950bc14e8a96c0bacb10
-size 10572641
+oid sha256:2d4376654f4f8cac12931a3cac4cab4f1cb15ebe73117deacfa4d4d9b3e837d5
+size 10572408


### PR DESCRIPTION
Fixes #279 and #277.

- Restored alpha to GoMePubNew linking panel
- Fixed name of Negilahn journal

#279 reported two issues that cannot be reproduced:
> Missing from ImageLibMod
xyeeshapagealphasketch03*1#0.hsm
xyeeshapagealphasketchgrass*1#0.hsm

As best I can tell, these mipmaps are present in the PRP and are listed in the ImageLibMod. Therefore, no action has been taken.