### PR TITLE
Add state for smashed Bevin heek table

### DIFF
--- a/compiled/dat/Neighborhood_District_nb01Ayhoheek5Man1Ruin.prp
+++ b/compiled/dat/Neighborhood_District_nb01Ayhoheek5Man1Ruin.prp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6ce6041ca4b006e33e5d2047f70a4b49c839a973159287602e4d08b01c198c2
+size 357492


### PR DESCRIPTION
This is missing the sound emitters and holographic sprites from the offline game (but they could be restored if there are strong feelings about them). It seemed in-character that a table smashed in February 2004 might have stopped working in the intervening 20+ years.