### PR TITLE
Add BkBookImages JSON.

### DIFF
--- a/compiled/dat/GUI_District_BkBookImages.prp
+++ b/compiled/dat/GUI_District_BkBookImages.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2d4376654f4f8cac12931a3cac4cab4f1cb15ebe73117deacfa4d4d9b3e837d5
-size 10572408
+oid sha256:091bf3f3a2ca0c81cabe84dfdea4aec09e80907a5a3ba3720747c0ea335a0d17
+size 7830053

--- a/sources/textures/tga/GUI/GUI_BkBookImages.json
+++ b/sources/textures/tga/GUI/GUI_BkBookImages.json
@@ -1,0 +1,387 @@
+{
+  "page": {
+    "age": "GUI",
+    "name": "BkBookImages",
+    "prefix": -2,
+    "suffix": 56
+  },
+  "object": {
+    "name": "daDummy",
+    "library": "StandardBookImageLib"
+  },
+  "images": [
+    { "$comment": "--- Mipmaps in ImageLibMod ---" },
+    "xYeeshaBookBorder.tga",
+    "xYeeshaBookCover.tga",
+    {
+      "name": "xyeeshabooklinkpanel*1#0.hsm",
+      "color": "xYeeshaBookLinkPanel.jpg",
+      "alpha": "xYeeshaBookLinkPanelAlpha.png"
+    },
+    {
+      "name": "xyeeshabookstamp*801#0.hsm",
+      "color": "xYeeshaBookStamp.tga"
+    },
+    "xYeeshaPageAlphaSketch03.tga",
+    {
+      "name": "xlinkpanelbevinbalc01*1#0.hsm",
+      "color": "xLinkPanelBevinBalc01.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelbevinbalc02*1#0.hsm",
+      "color": "xLinkPanelBevinBalc02.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelbevindefault*1#0.hsm",
+      "color": "xLinkPanelBevinDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelBlackVoid.tga",
+    {
+      "name": "xlinkpanelcleftdesert*1#0.hsm",
+      "color": "xLinkPanelCleftDesert.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpaneldokotahroof*1#0.hsm",
+      "color": "xLinkPanelDokotahRoof.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelgardendefault*1#0.hsm",
+      "color": "xLinkPanelGardenDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelgarrisondefault*1#0.hsm",
+      "color": "xLinkPanelGarrisonDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelgarrisonprison*1#0.hsm",
+      "color": "xLinkPanelGarrisonPrison.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelgirafromkemo*1#0.hsm",
+      "color": "xLinkPanelGiraFromKemo.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelkadishfromgallery*1#0.hsm",
+      "color": "xLinkPanelKadishFromGallery.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelkadishgallery*1#0.hsm",
+      "color": "xLinkPanelKadishGallery.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelkadishglowbalc*1#0.hsm",
+      "color": "xLinkPanelKadishGlowBalc.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelmystlibrary*1#0.hsm",
+      "color": "xLinkPanelMystLibrary.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelnexusdefault*1#0.hsm",
+      "color": "xLinkPanelNexusDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelpalacebalc02*1#0.hsm",
+      "color": "xLinkPanelPalaceBalc02.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelpalacebalc03*1#0.hsm",
+      "color": "xLinkPanelPalaceBalc03.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelteledahnchopshroom*1#0.hsm",
+      "color": "xLinkPanelTeledahnChopShroom.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelteledahndefault*1#0.hsm",
+      "color": "xLinkPanelTeledahnDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelteledahndock*1#0.hsm",
+      "color": "xLinkPanelTeledahnDock.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelTomahnaDesert.png",
+    "xLinkPanelUpperShroom.tga",
+    {
+      "name": "xlinkpanelyeeshavault*1#0.hsm",
+      "color": "xLinkPanelYeeshaVault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xDRCRubberStamp.tga",
+    {
+      "name": "xlinkpanelkadishdefault*1#0.hsm",
+      "color": "xLinkPanelKadishDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xDRCBookRubberStamp.tga",
+    "xDRCBookRubberStamp2.tga",
+    {
+      "name": "xlinkpanelbaroncityoffice*1#0.hsm",
+      "color": "xLinkPanelBaronCityOffice.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelercanasilo*1#0.hsm",
+      "color": "xLinkPanelErcanaSilo.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelGiraDefault.tga",
+    {
+      "name": "xlinkpaneldescentshaftfall*1#0.hsm",
+      "color": "xLinkPanelDescentShaftFall.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xYeeshaPageAlphaSketch01.tga",
+    "xYeeshaPageAlphaSketch02.tga",
+    "xYeeshaPageAlphaSketch04.tga",
+    "xYeeshaPageAlphaSketch05.tga",
+    "xYeeshaPageAlphaSketch06.tga",
+    "xYeeshaPageAlphaSketch07.tga",
+    "xYeeshaPageAlphaSketch09.tga",
+    "xYeeshaPageAlphaSketch10.tga",
+    "xYeeshaPageAlphaSketch12.tga",
+    "xYeeshaPageAlphaSketch08.tga",
+    {
+      "name": "xlinkpanelgarrisonnexus*1#0.hsm",
+      "color": "xLinkPanelGarrisonNexus.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xCoffeeStain03.tga",
+    "xCoffeeStain02.tga",
+    "xCoffeeStain01.tga",
+    "xYeeshaJournalCover.tga",
+    {
+      "name": "xyeeshabooknolinkpanel*1#0.hsm",
+      "color": "xYeeshaBookNoLinkPanel.jpg",
+      "alpha": "xYeeshaBookNoLinkPanelAlpha.jpg"
+    },
+    "xBookJourneyClothBookmark.tga",
+    "xYeeshaJournalGRDNHydrantSketch.tga",
+    "xYeeshaJournalGRSNHydrantSketch.tga",
+    "xYeeshaJournalKDSHHydrantSketch.tga",
+    "xYeeshaJournalTLDNHydrantSketch.tga",
+    {
+      "name": "xurucreditsjournalcover*1#0.hsm",
+      "color": "xUruCreditsJournalCover.jpg",
+      "alpha": "xUruCreditsJournalCoverAlpha.png"
+    },
+    "xTransparent.png",
+    "xBahroShare.tga",
+    "xDniONE.tga",
+    "xDniTWO.tga",
+    "xDniTHREE.tga",
+    "xDniFOUR.tga",
+    "xDniFIVE.tga",
+    "xDniSIX.tga",
+    "xDniSEVEN.tga",
+    "xDniEIGHT.tga",
+    "xDniNINE.tga",
+    "xDniTEN.tga",
+    "xKIJournalCover.tga",
+    "xUruCreditsLegalLogos.jpg",
+    "xSharperJournalCover.tga",
+    "xKingAileshJournalCover_eng.tga",
+    "xKingNaygenJournalCover_eng.tga",
+    "xKingAsemlefJournalCover_eng.tga",
+    "xMarriageJournalCover_eng.tga",
+    "xPregnancyJournalCover_eng.tga",
+    "xMaturityJournalCover_eng.tga",
+    "xClassStructureJournalCover_eng.tga",
+    "xKingRinerefJournalCover_eng.tga",
+    "xKingDemathJournalCover.tga",
+    "xKingShomatJournalCover.tga",
+    "xKingMeemenJournalCover_eng.tga",
+    "xKingKerathJournalCover_eng.tga",
+    "xGahreesenInfoJournalCover_eng.tga",
+    "xShomatStoryJournalCover_eng.tga",
+    "xYeeshaBookStampSquare.tga",
+    {
+      "name": "xyeeshabookshare_eng*801#0.hsm",
+      "color": "xYeeshaBookShare_eng.tga"
+    },
+    "xGreatZeroInfoJournalCover_eng.tga",
+    "xKingYableshanMTKJrnlCover_eng.tga",
+    "xKingMararonMTKJrnlCover_eng.tga",
+    "xPoetry1JrnlCover_eng.tga",
+    "xGarrisonWallJournalCover_eng.tga",
+    {
+      "name": "xlinkpanelercanapelletroom*1#0.hsm",
+      "color": "xLinkPanelErcanaPelletRoom.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xKINexusFAQJournalCover.tga",
+    "xYeeshaPageAlphaSketch13.tga",
+    "xYeeshaPageAlphaSketch14.tga",
+    "xYeeshaPageAlphaSketch15.tga",
+    "xYeeshaPageAlphaSketchClock.png",
+    "xYeeshaPageAlphaSketchFiremarbles.png",
+    "xYeeshaPageAlphaSketchFireplace.png",
+    "xYeeshaPageAlphaSketchGrass.png",
+    "xYeeshaPageAlphaSketchLeaf.png",
+    "xYeeshaPageAlphaSketchLushRelto.png",
+    "xYeeshaPageAlphaSketchStorm.png",
+    "xLinkPanelAhnonayTemple.tga",
+    {
+      "name": "xlinkpanelercanadefault*1#0.hsm",
+      "color": "xLinkPanelErcanaDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelederdelindefault*1#0.hsm",
+      "color": "xLinkPanelEderDelinDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpaneltsogarden*1#0.hsm",
+      "color": "xLinkPanelTsoGarden.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelSpyRoom.tga",
+    "xKedriStoryJournalCover_eng.tga",
+    "xMeemenStoryJournalCover_eng.tga",
+    "xMeertaStoryJournalCover_eng.tga",
+    "xYeeshaPageAlphaSketchBirds.png",
+    "xLinkPanelConcertHallFoyer.png",
+    "xBookSharePage512.jpg",
+    "xBahroYeeshaShare.jpg",
+    {
+      "name": "xlinkpanelcleftdesertdisabled*1#0.hsm",
+      "color": "xLinkPanelCleftDesertDisabled.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelGrtZero.tga",
+    {
+      "name": "xlinkpanelgrtzerolinkrm*1#0.hsm",
+      "color": "xLinkPanelGrtZeroLinkRm.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xYeeshaPageAlphaSketchCalendar.png",
+    "xYeeshaBookStampVsquish.png",
+    {
+      "name": "xbooksharepage512vsquish*1#0.hsm",
+      "color": "xBookSharePage512vsquish.jpg",
+      "alpha": "xBookSharePage512vsquishAlpha.png"
+    },
+    {
+      "name": "xlinkpanelnegilahndefault*1#0.hsm",
+      "color": "xLinkPanelNegilahnDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpaneltetsonotdefault*1#0.hsm",
+      "color": "xLinkPanelTetsonotDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelderenodefault*1#0.hsm",
+      "color": "xLinkPanelDerenoDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelpayiferendefault*1#0.hsm",
+      "color": "xLinkPanelPayiferenDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelcitygreattree*1#0.hsm",
+      "color": "xLinkPanelCityGreatTree.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpanelbahrocavelower*1#0.hsm",
+      "color": "xLinkPanelBahroCaveLower.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelBahroCaveUpper.tga",
+    {
+      "name": "xlinkpanelkirel*1#0.hsm",
+      "color": "xLinkPanelKirel.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xYeeshaPageAlphaSketchErcaPlant.png",
+    {
+      "name": "xbooksaveclothbookmark*1#0.hsm",
+      "color": "xBookSaveClothBookmark.jpg",
+      "alpha": "xBookSaveClothBookmarkAlpha.jpg"
+    },
+    {
+      "name": "xlinkpanelminkatadefault*1#0.hsm",
+      "color": "xLinkPanelMinkataDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xlinkpaneljalakdefault*1#0.hsm",
+      "color": "xLinkPanelJalakDefault.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    "xLinkPanelAhnonayVortex.tga",
+    {
+      "name": "xlinkpanelkveergreathall*1#0.hsm",
+      "color": "xLinkPanelKveerGreatHall.jpg",
+      "alpha": "xLinkPanelAlpha.png"
+    },
+    {
+      "name": "xYeeshaPageVeelay7.dds",
+      "color": "xYeeshaPageVeelay7.png"
+    },
+    {
+      "name": "xnegilahninfojournalcover*0#0.hsm",
+      "color": "xNegilahnInfoJournalCover.tga"
+    },
+    {
+      "color": "xBookmarkDniZero.tga",
+      "$comment": "This matches what was previously in the PRP. NPOT is 'fine' here because this isn't a texture.",
+      "resize": [150, 134]
+    },
+    {
+      "color": "xBookmarkDniZero2.tga",
+      "$comment": "This matches what was previously in the PRP. NPOT is 'fine' here because this isn't a texture.",
+      "resize": [134, 134]
+    },
+    "xBookShareSymbolOnly.jpg",
+    "xLinkPanelChisoPreniv.png",
+    "xLinkPanelChisoLower.png",
+    "xLinkPanelTokotahAlley.png",
+    "xLinkPanelFerryTerminal.png",
+    "xLinkPanelLibraryCourtyard.png",
+    "xLinkPanelPalaceAlcove.png",
+    "xLinkPanelGreatTreePubDefault.tga",
+    "xLinkPanelGoMePubNew.tga",
+    "xLinkPanelGuildPubWriters.tga",
+    "xLinkPanelGuildPubCartographers.tga",
+    "xLinkPanelGuildPubGreeters.tga",
+    "xLinkPanelGuildPubMaintainers.tga",
+    "xLinkPanelGuildPubMessengers.tga",
+
+    { "$comment": "--- Loose Mipmaps ---" },
+    {
+      "name": "xyeeshabookshare_fre*801#0.hsm",
+      "color": "xYeeshaBookShare_fre.tga",
+      "library": false
+    },
+    {
+      "name": "xyeeshabookshare_ger*801#0.hsm",
+      "color": "xYeeshaBookShare_ger.tga",
+      "library": false
+    }
+  ]
+}

--- a/sources/textures/tga/GUI/xBahroYeeshaShare.jpg
+++ b/sources/textures/tga/GUI/xBahroYeeshaShare.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54edb3990cbb11557c91146a9cbb4a7b4e65db5e6888ec526e44a2c133d158e3
+size 282287

--- a/sources/textures/tga/GUI/xBookSaveClothBookmark.jpg
+++ b/sources/textures/tga/GUI/xBookSaveClothBookmark.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba8eb3efc1dcfaa22de553d56c7dd37c08e49ea6b23015bac1982fb189ec32f9
+size 14107

--- a/sources/textures/tga/GUI/xBookSaveClothBookmarkAlpha.jpg
+++ b/sources/textures/tga/GUI/xBookSaveClothBookmarkAlpha.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4cc0d6ded1c75cc25ec607b89b0495a53e1aa72d12e2522408b8b3122296e26f
+size 14854

--- a/sources/textures/tga/GUI/xBookSharePage512.jpg
+++ b/sources/textures/tga/GUI/xBookSharePage512.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a265120a4518f6cc53c11cdf033450038fe93aee640b8ced6a98453839b0e6b
+size 41783

--- a/sources/textures/tga/GUI/xBookSharePage512vsquish.jpg
+++ b/sources/textures/tga/GUI/xBookSharePage512vsquish.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:579c1db0287b127b5b7977b177394826f5ddd2cead85690e6583ff01acdd8f55
+size 40013

--- a/sources/textures/tga/GUI/xBookSharePage512vsquishAlpha.png
+++ b/sources/textures/tga/GUI/xBookSharePage512vsquishAlpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5179182ad46e06df6619ac0620a5416654f3d6d7f3aede2c4360d043f741d0ea
+size 850

--- a/sources/textures/tga/GUI/xBookShareSymbolOnly.jpg
+++ b/sources/textures/tga/GUI/xBookShareSymbolOnly.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4bc7defcbd1de43712d701ab81efbfe9293838677e049dd40b4a15761d57281
+size 110979

--- a/sources/textures/tga/GUI/xLinkPanelAlpha.png
+++ b/sources/textures/tga/GUI/xLinkPanelAlpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed08230523fbc8631c37703e174939b0784d350b633788f53a4c30e99a02501f
+size 407

--- a/sources/textures/tga/GUI/xLinkPanelBahroCaveLower.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelBahroCaveLower.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a7987f9afda98990ad0b0390fa78ee7f6b5f93c150821c94adaddf5e8296a5d
+size 11239

--- a/sources/textures/tga/GUI/xLinkPanelBahroCaveLower.tga
+++ b/sources/textures/tga/GUI/xLinkPanelBahroCaveLower.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:db799438bba16ce3eb1c78d01d3f83065f100b886d05100fee4d67a599cd8ceb
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelBaronCityOffice.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelBaronCityOffice.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df0b927bab43ebf2b1da32185bd20d4eb99f86d30325e7ba322a5df14c6954fa
+size 12273

--- a/sources/textures/tga/GUI/xLinkPanelBaronCityOffice.tga
+++ b/sources/textures/tga/GUI/xLinkPanelBaronCityOffice.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:443088a398b08f202e57710580aa85c20aed494da9f58d1042bc84b2ae6ff1b2
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelBevinBalc01.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelBevinBalc01.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e3b48b25a62d6eff77f4528043fce99510c6ba4ac702ab1ea502fd6b6229befc
+size 14838

--- a/sources/textures/tga/GUI/xLinkPanelBevinBalc01.tga
+++ b/sources/textures/tga/GUI/xLinkPanelBevinBalc01.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9f648f5fd2d959fb1a67c9d413773116d44c2f58a5bfd76493b8f56d4bc7526f
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelBevinBalc02.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelBevinBalc02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ce9f629aa9ca03b0ebf82ced8796f17ce0ce482a7efdc135dc7669164129747
+size 16543

--- a/sources/textures/tga/GUI/xLinkPanelBevinBalc02.tga
+++ b/sources/textures/tga/GUI/xLinkPanelBevinBalc02.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:930eff488cb64cbca8ffe817abf6ec6a4ad505f447b9ae3ec9a0def61eecbde6
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelBevinDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelBevinDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d6b818ec24ef0f138e36a4861deff808799e78ad750b5d0de6dc96d3059aceb5
+size 16099

--- a/sources/textures/tga/GUI/xLinkPanelBevinDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelBevinDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b8cd6800b774a063738ea02200211451bdf366e11ae9fd09c467446a58dc38b6
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelChisoLower.png
+++ b/sources/textures/tga/GUI/xLinkPanelChisoLower.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8191dba12b0fcb36c5d970d2770265665b5dbadb4cd74863b2c3a3ae2a68b9a2
+size 104792

--- a/sources/textures/tga/GUI/xLinkPanelChisoPreniv.png
+++ b/sources/textures/tga/GUI/xLinkPanelChisoPreniv.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:26b5fe21767d5f8a29318bddfaf0d4c881a4697caabb88a0549e836316e01642
+size 101940

--- a/sources/textures/tga/GUI/xLinkPanelCityGreatTree.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelCityGreatTree.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:720676ded5f67aaa5f1057f4dd02b8f35ff3c0fd0328eaa7156dd36f646efd7b
+size 7087

--- a/sources/textures/tga/GUI/xLinkPanelCleftDesert.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelCleftDesert.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80e5418d40472e0f0dc1750e5e835889da59168e52468bf7c05758531d093c82
+size 12167

--- a/sources/textures/tga/GUI/xLinkPanelCleftDesert.tga
+++ b/sources/textures/tga/GUI/xLinkPanelCleftDesert.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d30cacf66badfa0a3686fb737f0e5c43a3ee4769b3e888ed4a3b1db57829f1a1
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelCleftDesertDisabled.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelCleftDesertDisabled.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2551b7cba591267a04549221a155da23a7f8f1ebc0312672f0ce8786aafb37b4
+size 24772

--- a/sources/textures/tga/GUI/xLinkPanelDerenoDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelDerenoDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:714c5dbd3472d37094ba37b23466f4b96d3d9e407f0118ff192579c138ce4cde
+size 14218

--- a/sources/textures/tga/GUI/xLinkPanelDescentShaftFall.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelDescentShaftFall.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:136b8448cb3ea9e113b00576b4cb6802b2debdf9645f52d3164d6962207ca50f
+size 10720

--- a/sources/textures/tga/GUI/xLinkPanelDescentShaftFall.tga
+++ b/sources/textures/tga/GUI/xLinkPanelDescentShaftFall.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bbad63c1f490f5db67d3721437a8e57232b3bda82f7ffc5026c132c69a9bc5fb
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelDokotahRoof.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelDokotahRoof.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5860f95ec60f3077b9c8440e7413f42497d4b28b7fbef57418885be6a6c39e8
+size 13796

--- a/sources/textures/tga/GUI/xLinkPanelDokotahRoof.tga
+++ b/sources/textures/tga/GUI/xLinkPanelDokotahRoof.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69828a3de9fba865aa9053d12e6ace0572049358b3af496ee2a83380f9a9b7ef
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelEderDelinDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelEderDelinDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1b9d0b43b68db2e2c91d8157debcfda33c8c330f48217a01e0c85bfbe844141
+size 14876

--- a/sources/textures/tga/GUI/xLinkPanelErcanaDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelErcanaDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dd131c51ce161419c0378da4673a6e7604654744bb7ae0c1f4c6499a3789ab8
+size 12215

--- a/sources/textures/tga/GUI/xLinkPanelErcanaDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelErcanaDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ac794e45f6b736dfc7aa7e98ae0ea496111d6d5bb541db898d3776e2acad342
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelErcanaPelletRoom.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelErcanaPelletRoom.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a2247fa974f4332e8981da2726dcf8f71be40188249cf9f7dec58327be98ad9
+size 12837

--- a/sources/textures/tga/GUI/xLinkPanelErcanaPelletRoom.tga
+++ b/sources/textures/tga/GUI/xLinkPanelErcanaPelletRoom.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:806f99a9170a49a39322c68392b04cdb27ba538a81a073d9ad35f88dcc11766b
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelErcanaSilo.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelErcanaSilo.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:912e70d51f8070e0d4227611f86759ffca85aa9879170ba8bbe0055c47843ca6
+size 11699

--- a/sources/textures/tga/GUI/xLinkPanelErcanaSilo.tga
+++ b/sources/textures/tga/GUI/xLinkPanelErcanaSilo.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:855babfc8ad5bad70c6db51b9090336068ce0bd47e7b5866ebd1f6a523ee7393
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGardenDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelGardenDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9e22dc453edc456cddd1a07fabf2cbd0d64cbd0ab26d220fc757740d085e785
+size 18388

--- a/sources/textures/tga/GUI/xLinkPanelGardenDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGardenDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ed882f0fd7f5e30e6b7cd021f1d27b6ae187f41c0ec08bfe829d1e4abdad874e
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGarrisonDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelGarrisonDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:243e3d8311ffb18d56be25e93332923d3fdad0bfe1d67b8931f9ddba065c20b6
+size 16823

--- a/sources/textures/tga/GUI/xLinkPanelGarrisonDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGarrisonDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e8395ae5e3da6bec68290cc8b9a970e9aba478ce35e5cbf3b905b4f075433434
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGarrisonNexus.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelGarrisonNexus.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57d6abc97098633218113f93ff0b0faddedc3622fd2448261bda4f1a64805242
+size 15818

--- a/sources/textures/tga/GUI/xLinkPanelGarrisonNexus.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGarrisonNexus.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c1f651e6bf1d90254286459c32964db1bff6b75fd2d2153bf9c4fe42e9ecc318
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGarrisonPrison.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelGarrisonPrison.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee55934fcdb49231aac4a7ef0504e244d6563c4fa0cb000c227adb2a06f00695
+size 8280

--- a/sources/textures/tga/GUI/xLinkPanelGarrisonPrison.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGarrisonPrison.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5a2287ad0043893feda2f7aeb6273a863f92cd7310d769cfa15ecfb67ab737b5
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGiraFromKemo.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelGiraFromKemo.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a58945e962dfe148eab4fb9a73091dcd076b3313b5985f385e3dde0cced1ede
+size 15317

--- a/sources/textures/tga/GUI/xLinkPanelGiraFromKemo.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGiraFromKemo.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b81565e207242ed37b24fc30bf21915c4801e6a885051a376948bcbeb47aff56
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGrtZeroLinkRm.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelGrtZeroLinkRm.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa9d028511c8dda24730c48c5d65b3192d9908e33c820b52d8ccc2daa5425df4
+size 13877

--- a/sources/textures/tga/GUI/xLinkPanelGrtZeroLinkRm.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGrtZeroLinkRm.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a76f289c087aa69c2850c027ad50c83d3be9575a20f98e4556c85b5b443c3796
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGuildPubCartographers.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGuildPubCartographers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4d65b92f9289aba800633c05b1e432b48debf7990735965b4f2c03b522102883
+size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGuildPubGreeters.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGuildPubGreeters.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78f198659002586199546fa8c4d9d67d97c53f6a32d3480263d2921b3abf9983
+size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGuildPubMaintainers.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGuildPubMaintainers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d67e3e568389d275eca02a5e37857aff9ff320ddb634297fca45635cef8c10ec
+size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGuildPubMessengers.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGuildPubMessengers.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2247dad7bf19a417b891d2e70ef941499e3075cab6a4a4c4c04bd90e073043ab
+size 524332

--- a/sources/textures/tga/GUI/xLinkPanelGuildPubWriters.tga
+++ b/sources/textures/tga/GUI/xLinkPanelGuildPubWriters.tga
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6f3b5d64207232005bb601ac3f5c873aa4004993d9180661f3e6b821d0f079f
+size 524332

--- a/sources/textures/tga/GUI/xLinkPanelJalakDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelJalakDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b171c1bd41f475564053c07b7892a9b89051c085bc537d6bcd3d2e4ce663139d
+size 15871

--- a/sources/textures/tga/GUI/xLinkPanelKadishDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelKadishDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b84ae96a769e9172136132754b6ee4ab7f60253de03821deea7127ac78db1b8a
+size 11818

--- a/sources/textures/tga/GUI/xLinkPanelKadishDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelKadishDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d8700d720dde1aaf3bcb391ee450e59cd230eae34e808cb0f06c1719d956741d
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelKadishFromGallery.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelKadishFromGallery.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8d69a3e6160b21d4898f2276ce1ec9a2b91cbbcae4056bcc688aabead238464
+size 12600

--- a/sources/textures/tga/GUI/xLinkPanelKadishFromGallery.tga
+++ b/sources/textures/tga/GUI/xLinkPanelKadishFromGallery.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d517ac87a28a6bff6ad8618f1e05e1b462042a25d8b8881c21543a0fa5f4b641
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelKadishGallery.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelKadishGallery.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5102e7b110874e7a7930d3872fc703c8ac5908226e01280d262e8e54361a348e
+size 14917

--- a/sources/textures/tga/GUI/xLinkPanelKadishGallery.tga
+++ b/sources/textures/tga/GUI/xLinkPanelKadishGallery.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f6327fec7bc4a5731a67785d778f0447f63a2e0b23f9ce029a9e7aa51f8a70cb
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelKadishGlowBalc.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelKadishGlowBalc.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2c83f106fc977791a48a6f68c5bf3a08dfbddf3ff39ec2c5a66739aa3b8d9cff
+size 10447

--- a/sources/textures/tga/GUI/xLinkPanelKadishGlowBalc.tga
+++ b/sources/textures/tga/GUI/xLinkPanelKadishGlowBalc.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:321649e0dfff14836f7195a47003a1d71023eb68475d1abf4e11fb89d3e5a5ea
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelKirel.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelKirel.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:638c8fde37d665d6d04848685d1bde884f05cfa2e1b3c8ef9a42ade25ac54481
+size 15401

--- a/sources/textures/tga/GUI/xLinkPanelKirelDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelKirelDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a867128a2f785ed1ca3807adb2f5a9b891d033fd3b966556052a771f33c3656d
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelKveer.tga
+++ b/sources/textures/tga/GUI/xLinkPanelKveer.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:feb7b57e99df9c7b267c9ab90d3e036ba42208827eb339b733189251ab70ee84
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelKveerGreatHall.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelKveerGreatHall.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5553bca9904918f96e6bff7f4255c5b6470cdf456e5b82f019bf4289e016b14f
+size 13547

--- a/sources/textures/tga/GUI/xLinkPanelMinkataDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelMinkataDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcb8249ade296cbf05f3a95f325cbe508d92c02961ac1c65ed4476adcbe0a35a
+size 11098

--- a/sources/textures/tga/GUI/xLinkPanelMystLibrary.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelMystLibrary.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0effe39b787f60dd8424ed97cedc91ab733a00e4bfaa5f759b3a797455e1fd92
+size 14346

--- a/sources/textures/tga/GUI/xLinkPanelMystLibrary.tga
+++ b/sources/textures/tga/GUI/xLinkPanelMystLibrary.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49c3c6a80b519aaa24d159c639360f95221dd4fb6a385442845a4ceea97beaaa
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelNegilahnDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelNegilahnDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5cfd41600097786c1c5c9c224dcbf355aae152a722fca141f813eae80e109298
+size 15702

--- a/sources/textures/tga/GUI/xLinkPanelNegilahnDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelNegilahnDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9d252e0cf2f75295b99977bb9c5d3091e5f9acaa283f5befc3607333f85eb7cf
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelNexusDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelNexusDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d871bdc5c14f3aa92b2a3b1fe131b74d85c73cad59288755d6d207a2d005d12
+size 11503

--- a/sources/textures/tga/GUI/xLinkPanelNexusDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelNexusDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf5ac0db5cac33310cf8a8ea439e8f946dc2c0a439cc3e514a1b2a7cbcf414a0
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelPalaceBalc02.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelPalaceBalc02.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbc70228466b27d3bbbb66873e2a3f1f90caed1092cbc09a0ff1eb1b05021f0c
+size 11493

--- a/sources/textures/tga/GUI/xLinkPanelPalaceBalc02.tga
+++ b/sources/textures/tga/GUI/xLinkPanelPalaceBalc02.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3399e86c467dd61d894e71557ce4399cb98f09bd7cefdb8b1643bb83aebdf4c6
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelPalaceBalc03.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelPalaceBalc03.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c1b273ca4aec175eab2e95b94105865cc7b00e3cc6a115159df51b1dfc7b6f3
+size 11573

--- a/sources/textures/tga/GUI/xLinkPanelPalaceBalc03.tga
+++ b/sources/textures/tga/GUI/xLinkPanelPalaceBalc03.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b87aa7f012553a57f8ab79a4225cfa2067bdc88d01a99d64b92be0e263fd9c05
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelPayiferenDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelPayiferenDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c48fb6a1dc02de1905034f40c606ef9da7e9192d937cf1530cec85a6116a7b76
+size 11518

--- a/sources/textures/tga/GUI/xLinkPanelTeledahnChopShroom.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelTeledahnChopShroom.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d807c851219d4e50a6740fd6a61ef4fd4f92cf718b3d38e8f1c15bbf4ee214d
+size 14434

--- a/sources/textures/tga/GUI/xLinkPanelTeledahnChopShroom.tga
+++ b/sources/textures/tga/GUI/xLinkPanelTeledahnChopShroom.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:72ff405aca0260153accde1e0a043e3808e8f78c07d3f05dc88fa005f768999a
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelTeledahnDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelTeledahnDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ec14611385c73eaf5c2038832abe7e3d97ad4642c5e2b8032c4c71eba5c49b91
+size 12636

--- a/sources/textures/tga/GUI/xLinkPanelTeledahnDock.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelTeledahnDock.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:71b753235de9b086e531ca468835129c628567b82bb0577407f9537e4dcafab9
+size 12455

--- a/sources/textures/tga/GUI/xLinkPanelTeledahnDock.tga
+++ b/sources/textures/tga/GUI/xLinkPanelTeledahnDock.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e894fbdbd8e153af911ccbe5237ef38b65b7ab11fbcd875f62650871540daed0
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelTetsonotDefault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelTetsonotDefault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c789a7e9e1fdcfae107bf3dc36e0d5ca8b485bd3f1497729f24278746178a85a
+size 4428

--- a/sources/textures/tga/GUI/xLinkPanelTodelmerDefault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelTodelmerDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e33c057eea80025c545d2e8851c03cd15ab0f095fc005ce8006d8492902edf6a
-size 524332

--- a/sources/textures/tga/GUI/xLinkPanelTsoGarden.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelTsoGarden.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:12ce1412078cc632046ef36c57dd1f328b387482a4cac7625ec84a9822516fe5
+size 15918

--- a/sources/textures/tga/GUI/xLinkPanelYeeshaVault.jpg
+++ b/sources/textures/tga/GUI/xLinkPanelYeeshaVault.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df37896665a3140250417fd79a74a107ef8b0c256cf2cf38f58e2df01944231e
+size 14054

--- a/sources/textures/tga/GUI/xLinkPanelYeeshaVault.tga
+++ b/sources/textures/tga/GUI/xLinkPanelYeeshaVault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f442d17c2681a590c172e2fb01efca4693a9410cb4f37045309511e2583a0e68
-size 524332

--- a/sources/textures/tga/GUI/xLinkpanelTeledahnDefault.tga
+++ b/sources/textures/tga/GUI/xLinkpanelTeledahnDefault.tga
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:917e8e29e64b92d2319cfb31f9ddc91cd6b75a6cf456de38c3aacc1393a4d6ee
-size 524332

--- a/sources/textures/tga/GUI/xTransparent.png
+++ b/sources/textures/tga/GUI/xTransparent.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b327617cc5c83f5b3eabbd5718e9140d506253e03ab37a9aa5980e4c79285362
+size 588

--- a/sources/textures/tga/GUI/xUruCreditsJournalCover.jpg
+++ b/sources/textures/tga/GUI/xUruCreditsJournalCover.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05acdf6fe249f382a0851dc2093f97dcc459d15328689f3181eb71ff6948d331
+size 242094

--- a/sources/textures/tga/GUI/xUruCreditsJournalCoverAlpha.png
+++ b/sources/textures/tga/GUI/xUruCreditsJournalCoverAlpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8760c40dabf808ddd02df24377b51ae9848e146716643e18b5ebc524ee9ad4a9
+size 2383

--- a/sources/textures/tga/GUI/xUruCreditsLegalLogos.jpg
+++ b/sources/textures/tga/GUI/xUruCreditsLegalLogos.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30ea4d374b06e6cb480311eb50376983ae303e3e5d41a486143b3b360f44d805
+size 3043

--- a/sources/textures/tga/GUI/xYeeshaBookLinkPanel.jpg
+++ b/sources/textures/tga/GUI/xYeeshaBookLinkPanel.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87134111c58a544b961b6001aa506819d11c85e1a2c724186806feb3e65d4843
+size 9709

--- a/sources/textures/tga/GUI/xYeeshaBookLinkPanelAlpha.png
+++ b/sources/textures/tga/GUI/xYeeshaBookLinkPanelAlpha.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f31cce1065111d6f9f64416065be09785223ab47cb8bbc2d2bafeb569af7bb2
+size 399

--- a/sources/textures/tga/GUI/xYeeshaBookNoLinkPanel.jpg
+++ b/sources/textures/tga/GUI/xYeeshaBookNoLinkPanel.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35d88ad35bb9365cae5f04fbb7bbcb62cba17e88c3704cf00e73018aa680437e
+size 17560

--- a/sources/textures/tga/GUI/xYeeshaBookNoLinkPanelAlpha.jpg
+++ b/sources/textures/tga/GUI/xYeeshaBookNoLinkPanelAlpha.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:638ab437d87b3f971c16054960b29d82276465570ea07d7bd42c2c2da58fbf9e
+size 21533

--- a/sources/textures/tga/GUI/xYeeshaBookStampVsquish.png
+++ b/sources/textures/tga/GUI/xYeeshaBookStampVsquish.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0ee06df2d89a92ce9610bf737c6e7c3487771e3f7f6f32d8b79c6a5750124ad
+size 25345

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchBirds.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchBirds.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c485e29f2f4dedfb5b54eca4a47b7c5f4b7ca871dcc9fe919345037c16f05ac4
+size 10525

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchCalendar.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchCalendar.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54f95a642f50dc31d3f1b50523d4f63823f7120e78c0ed6e198c2c0db2f76ac6
+size 11597

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchClock.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchClock.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0cb064c2f31619d6906b912b7a1ec98c105efcf6f59fe63cdf09099da33fed20
+size 14105

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchErcaPlant.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchErcaPlant.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fea34c9eae72a3916056f86c1f7c7ef40eba3e2dd0e9fdee3bd4f162ea12ba56
+size 11621

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchFireMarbles.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchFireMarbles.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56913479bc7743cca4ffedeff6e6861850f4df3bc3bac8adca420bd308e87d73
+size 12844

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchFireplace.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchFireplace.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2e005eeb6bfe5970d30063f55936095cc43168c5f97cb38ba7e037ec723e63ca
+size 11731

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchGrass.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchGrass.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:faf2232c5dd6fed14f4cabd8bbdf89b934e99f8c07ec63208a8796e45e19c027
+size 10443

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchLeaf.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchLeaf.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3e59df230bdb8b3a3e98ed3147e044f0646c05b57b5d8839a9c36784ec837f6f
+size 12535

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchLushRelto.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchLushRelto.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83c6a5738a4b4345bedbedcb9c77e3baa402394866517eb256754c75dc89b6d1
+size 15650

--- a/sources/textures/tga/GUI/xYeeshaPageAlphaSketchStorm.png
+++ b/sources/textures/tga/GUI/xYeeshaPageAlphaSketchStorm.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:214bd3a9e9133e1cc16ff83d274ae9c8b63f8a8701ebe064c7234c064efb5613
+size 8060

--- a/sources/textures/tga/GUI/xYeeshaPageVeelay7.png
+++ b/sources/textures/tga/GUI/xYeeshaPageVeelay7.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ca89a43f9d8730b1ace08abffa452c00c86a9d4c45511ad93a657f5c7d12283
+size 20212


### PR DESCRIPTION
This adds a JSON file and all of the source images required to rebuild GUI_District_BkBookImages.prp using my [MakeImageLibPRP.py script](https://github.com/Hoikas/moul-utils/blob/master/MakeImageLibPRP.py). The source images were all ripped from the previous BkBookImages.prp and compared with the files already in the sources directory. If an identical lossless version already existed, the lossy version from the PRP was discarded. Otherwise, the lossy version from the PRP has been added here and is re-imported to the the new PRP.

The linking panels are primarily the trouble spots here - they were mostly reshot for MOUL, but what we have here is mostly the TPotS linking panel images. Some of them are identical. Many of the Yeesha journey Ages use the same angle but have been brightened somewhat. As stated above, I brought in the MOUL reshots if there was any discernible difference. No effort was made to correct problems with any linking panels. So, for example, the lower pellet cave linking panel still has a cursor in it.

The resuling diff on BkBookImages.prp should be minimal. There were some RLE changes reevaluated, and any PNGs in BkBookImages.prp were compressed to JPEG. In my work, I discovered using lossless compression resulted in a 60 MB BkBookImages.prp, which is undesirable.

I also deleted all of the TPotS panels that did not match the MOUL variants. Once this is merged, #117 and #281 can be more trivially rebased.