### PR TITLE
Fixes for music not running on the music channel

### DIFF
--- a/compiled/dat/Kadish_District_kdshVaultExtrYeesha.prp
+++ b/compiled/dat/Kadish_District_kdshVaultExtrYeesha.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bb2e0527b6d7282998b28915c6e210f2ca88d9c1e1fd4d5b7d482f59d5e70011
-size 988658
+oid sha256:a998aebc6af9784e144240e75c3845e4930fc56f12d4f5d46026b03bf4897fe8
+size 988558

--- a/compiled/dat/Minkata_District_minkExteriorNight.prp
+++ b/compiled/dat/Minkata_District_minkExteriorNight.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:55ab1f3d2d384f3477ca46d0ae4a232e9a59d68c5955d2fb327c70556f12fd75
-size 10849230
+oid sha256:b512f9e7e9661a4e274858c2d7da26db24433df0172f10914183e5c6eaa1b31f
+size 10304636

--- a/compiled/dat/spyroom_District_spyroom.prp
+++ b/compiled/dat/spyroom_District_spyroom.prp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7fd389869781c933551cbfc7d1c352932854e61e96abce1f585e4dab0fe81405
+oid sha256:f49a162042890fbd8a412c8c00e2ec4d8307096c4d603e47a1c6abd07211457c
 size 1097412


### PR DESCRIPTION
I noticed a few instances of music tracks not running on the music channel so you could hear them with music muted. They were easy enough to fix by just changing the sound type in their prps.

Fixed:
- Alternate Kadish Vault Music
- spyroom Music
- Minkata Night music that triggers when running through the symbol and beginning the constellation rotation

Not fixed but still taking note:
- Descent also has this problem but since i know that is actively worked on by the community I decided not to touch it. As far as I was told this is already fixed in the WIP blend file anyway.